### PR TITLE
Fix #167, fix #195: Set heights and overflow to fix scrolling.

### DIFF
--- a/src/browser_action/components/TrackedProductList.css
+++ b/src/browser_action/components/TrackedProductList.css
@@ -9,9 +9,16 @@
 }
 
 .product-list {
-  margin: 0;
-  padding: 0;
   list-style-type: none;
+  margin: 0;
+
+  /*
+    max popup height - (titlebar height + track button height) = max list height
+    600px - (42px + 36px) = 522px
+   */
+  max-height: 522px;
+  overflow-y: auto;
+  padding: 0;
 }
 
 .product-list .product-list-item {

--- a/src/browser_action/index.css
+++ b/src/browser_action/index.css
@@ -15,11 +15,12 @@ body {
   font: message-box;
   font-size: 13px;
   margin: 0;
+  max-height: 600px;
   padding: 0;
 }
 
 #browser-action-app {
-  width: 320px;
+  min-width: 320px;
 }
 
 /** Links */


### PR DESCRIPTION
The product list now properly overflows, and max heights have been set to match
the Firefox-enforced 600px height limit for popup panels.