### PR TITLE
Fix deploy script and other changes.

### DIFF
--- a/.circleci/deploy_addon.sh
+++ b/.circleci/deploy_addon.sh
@@ -9,7 +9,7 @@ set -e
 
 ADDON_ID="shopping-testpilot@mozilla.org"
 ADDON_VERSION=${CIRCLE_TAG:1}
-ADDON_FILE="web-ext-artifacts/firefox_shopping-${ADDON_VERSION}-signed.xpi"
+ADDON_FILE="web-ext-artifacts/price_wise-${ADDON_VERSION}-signed.xpi"
 test -f $ADDON_FILE
 
 MAX_AGE=30 # We can up this at some point, but keeping it low while we work out the kinks

--- a/src/browser_action/components/EmptyOnboarding.css
+++ b/src/browser_action/components/EmptyOnboarding.css
@@ -9,8 +9,9 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  margin: 16px;
+  margin: 16px auto;
   text-align: center;
+  width: 288px;
 }
 
 .empty-onboarding .hero {

--- a/src/browser_action/index.css
+++ b/src/browser_action/index.css
@@ -16,6 +16,7 @@ body {
   font-size: 13px;
   margin: 0;
   max-height: 600px;
+  overflow: auto;
   padding: 0;
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -6,7 +6,7 @@
 /**
  * Config values that are shared between files or otherwise useful to have in
  * a separate file. Config values can be overridden by setting a pref at the
- * subtree extensions.shopping@mozilla.org.prefName.
+ * subtree extensions.shopping-testpilot@mozilla.org.prefName.
  *
  * Content scripts cannot access the preference API, and thus cannot use this
  * module to get config values. Use commerce/config/content instead to use

--- a/src/experiment_apis/shoppingPrefs/api.js
+++ b/src/experiment_apis/shoppingPrefs/api.js
@@ -6,7 +6,7 @@
 this.shoppingPrefs = class extends ExtensionAPI {
   getAPI() {
     const {Services} = ChromeUtils.import('resource://gre/modules/Services.jsm', {});
-    const branch = Services.prefs.getBranch('extensions.shopping@mozilla.org.');
+    const branch = Services.prefs.getBranch('extensions.shopping-testpilot@mozilla.org.');
     return {
       shoppingPrefs: {
         async getBoolPref(prefName, defaultValue) {

--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -1,9 +1,9 @@
 module.exports = {
   run: {
     pref: [
-      'extensions.shopping@mozilla.org.priceCheckInterval=30000',
-      'extensions.shopping@mozilla.org.priceCheckTimeoutInterval=30000',
-      'extensions.shopping@mozilla.org.iframeTimeout=10000',
+      'extensions.shopping-testpilot@mozilla.org.priceCheckInterval=30000',
+      'extensions.shopping-testpilot@mozilla.org.priceCheckTimeoutInterval=30000',
+      'extensions.shopping-testpilot@mozilla.org.iframeTimeout=10000',
       'network.cookie.cookieBehavior=3', // See Issue #183
     ],
     startUrl: [


### PR DESCRIPTION
This is a pile of tiny fixes that I'm comfortable self-reviewing in order to get a new release out tonight:

1. Updates the deploy script to use the correct filename for the add-on file, which changed when we changed the add-on name. The 5.0.0 release failed due to this.
2. Updates the preference subtree for overriding config values to use the new add-on ID; I missed this when switching to the new ID.
3. I missed that the CSS changes earlier today made the empty onboarding view expand to an unreasonable width; the changes in this PR fix the width, and also ensure the onboarding view looks correct when the toolbar icon is pinned to the overflow menu.