### PR TITLE
Fix add-on filename in Circle config as well.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - run:
           name: Store XPI name in environment variable
           command: |
-            echo 'export XPI_NAME=firefox_shopping-${CIRCLE_TAG:1}' >> $BASH_ENV
+            echo 'export XPI_NAME=price_wise-${CIRCLE_TAG:1}' >> $BASH_ENV
       - run:
           name: Install dependencies
           command: |


### PR DESCRIPTION
Turns out `ripgrep` doesn't search `.circleci/config.yml` by default, and I missed this. Sigh.