### PR TITLE
Fix #217: Clamp the sizing of the title/details column.

### DIFF
--- a/src/browser_action/components/ProductCard.css
+++ b/src/browser_action/components/ProductCard.css
@@ -9,7 +9,7 @@
   cursor: pointer;
   display: grid;
   gap: 8px;
-  grid-template-columns: 20px auto 64px;
+  grid-template-columns: 20px minmax(204px, 284px) 64px;
   grid-template-rows: auto 20px;
   height: 88px;
   overflow: hidden;


### PR DESCRIPTION
This prevents it from expanding indefinitely, but allows some flex to
accommodate the increased width when pinned to the overflow menu.