### PR TITLE
Fix Amazon issues with the Breath of the Wild product page.

### DIFF
--- a/src/background/extraction.js
+++ b/src/background/extraction.js
@@ -58,3 +58,17 @@ export async function handleExtractedProductData({extractedProduct}, sender) {
   // Update saved product data if it exists
   updateProductWithExtracted(extractedProduct);
 }
+
+/**
+ * Resets the browser action and re-triggers extraction when the History API is
+ * used to change a tab's URL.
+ * @param {object} details
+ */
+export async function handleHistoryStateUpdated({tabId}) {
+  if (tabId) {
+    browser.browserAction.setPopup({popup: null, tabId});
+    browser.browserAction.setBadgeBackgroundColor({color: null, tabId});
+    browser.browserAction.setBadgeText({text: null, tabId});
+    await browser.tabs.sendMessage(tabId, {type: 'reextract-product'});
+  }
+}

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -10,6 +10,7 @@
  */
 
 import config from 'commerce/config';
+import {handleHistoryStateUpdated} from 'commerce/background/extraction';
 import {handleConnect, handleMessage} from 'commerce/background/messages';
 import {handleNotificationClicked, handlePriceAlerts} from 'commerce/background/price_alerts';
 import {handleWebRequest, updatePrices} from 'commerce/background/price_updates';
@@ -62,6 +63,15 @@ import {registerEvents, handleWidgetRemoved} from 'commerce/telemetry/extension'
     handleWebRequest,
     webRequestFilter,
     ['blocking', 'responseHeaders'],
+  );
+
+  // Set up listener to trigger re-extraction when a page changes the URL via
+  // the history API.
+  browser.webNavigation.onHistoryStateUpdated.addListener(
+    handleHistoryStateUpdated,
+    {url: [
+      {schemes: ['https', 'http']},
+    ]},
   );
 
   // Make sure the store is loaded before we check prices.

--- a/src/extraction/index.js
+++ b/src/extraction/index.js
@@ -115,4 +115,12 @@ async function attemptExtraction() {
   const resend = () => sendProductToBackground(extractedProduct);
   setTimeout(resend, 5000);
   setTimeout(resend, 10000);
+
+  browser.runtime.onMessage.addListener(async (message) => {
+    // Re-extract the product if requested
+    if (message.type === 'reextract-product') {
+      extractedProduct = await attemptExtraction();
+      await sendProductToBackground(extractedProduct);
+    }
+  });
 }());

--- a/src/extraction/selector/selectors.js
+++ b/src/extraction/selector/selectors.js
@@ -55,6 +55,7 @@ const fallbackExtractionData = [
         ['#landingImage', fromProperty('src')],
         ['#imgBlkFront', fromProperty('src')],
         ['#ebooksImgBlkFront', fromProperty('src')],
+        ['#main-image-container img', fromProperty('src')],
       ],
     },
   },

--- a/src/extraction/selector/selectors.js
+++ b/src/extraction/selector/selectors.js
@@ -6,9 +6,17 @@ import {parsePrice} from 'commerce/extraction/utils';
 
 function inUnits(fn) {
   return (element) => {
-    const priceString = fn(element);
-    return parsePrice([priceString]);
+    let tokens = fn(element);
+    if (!Array.isArray(tokens)) {
+      tokens = [tokens];
+    }
+
+    return parsePrice(tokens);
   };
+}
+
+function fromChildrenText() {
+  return (element => Array.from(element.childNodes).map(node => node.textContent));
 }
 
 function fromProperty(property) {
@@ -33,15 +41,15 @@ const fallbackExtractionData = [
         ['.product-title', fromProperty('innerText')],
       ],
       price: [
-        ['#priceblock_dealprice', inUnits(fromProperty('innerText'))],
-        ['#priceblock_ourprice', inUnits(fromProperty('innerText'))],
-        ['#price_inside_buybox', inUnits(fromProperty('innerText'))],
-        ['#buybox .a-color-price', inUnits(fromProperty('innerText'))],
+        ['#priceblock_dealprice', inUnits(fromChildrenText())],
+        ['#priceblock_ourprice', inUnits(fromChildrenText())],
+        ['#price_inside_buybox', inUnits(fromChildrenText())],
+        ['#buybox .a-color-price', inUnits(fromChildrenText())],
         ['input[name="displayedPrice"]', inUnits(fromAttribute('value'))],
-        ['.a-size-large.a-color-price.guild_priceblock_ourprice', inUnits(fromProperty('innerText'))],
-        ['.a-color-price.a-size-medium.a-align-bottom', inUnits(fromProperty('innerText'))],
-        ['.display-price', inUnits(fromProperty('innerText'))],
-        ['.offer-price', inUnits(fromProperty('innerText'))],
+        ['.a-size-large.a-color-price.guild_priceblock_ourprice', inUnits(fromChildrenText())],
+        ['.a-color-price.a-size-medium.a-align-bottom', inUnits(fromChildrenText())],
+        ['.display-price', inUnits(fromChildrenText())],
+        ['.offer-price', inUnits(fromChildrenText())],
       ],
       image: [
         ['#landingImage', fromProperty('src')],
@@ -57,7 +65,7 @@ const fallbackExtractionData = [
         ['.sku-title h1', fromProperty('innerText')],
       ],
       price: [
-        ['.priceView-hero-price.priceView-purchase-price', inUnits(fromProperty('innerText'))],
+        ['.priceView-hero-price.priceView-purchase-price', inUnits(fromChildrenText())],
       ],
       image: [
         ['img.primary-image', fromProperty('src')],
@@ -72,10 +80,10 @@ const fallbackExtractionData = [
         ['.product-title', fromProperty('innerText')],
       ],
       price: [
-        ['#prcIsum', inUnits(fromProperty('innerText'))],
-        ['#orgPrc', inUnits(fromProperty('innerText'))],
-        ['#mm-saleDscPrc', inUnits(fromProperty('innerText'))],
-        ['.display-price', inUnits(fromProperty('innerText'))],
+        ['#prcIsum', inUnits(fromChildrenText())],
+        ['#orgPrc', inUnits(fromChildrenText())],
+        ['#mm-saleDscPrc', inUnits(fromChildrenText())],
+        ['.display-price', inUnits(fromChildrenText())],
       ],
       image: [
         ['#icImg', fromProperty('src')],
@@ -91,7 +99,7 @@ const fallbackExtractionData = [
       ],
       price: [
         ['#ajaxPrice', inUnits(fromAttribute('content'))],
-        ['#ajaxPriceAlt', inUnits(fromProperty('innerText'))],
+        ['#ajaxPriceAlt', inUnits(fromChildrenText())],
       ],
       image: [
         ['#mainImage', fromProperty('src')],
@@ -106,9 +114,9 @@ const fallbackExtractionData = [
         ['h1.prod-ProductTitle', fromProperty('innerText')],
       ],
       price: [
-        ['.PriceRange.prod-PriceHero', inUnits(fromProperty('innerText'))],
+        ['.PriceRange.prod-PriceHero', inUnits(fromChildrenText())],
         ['.price-group', inUnits(fromAttribute('aria-label'))],
-        ['.price-group', inUnits(fromProperty('innerText'))],
+        ['.price-group', inUnits(fromChildrenText())],
       ],
       image: [
         ['.prod-hero-image-image', fromProperty('src')],
@@ -123,7 +131,7 @@ const fallbackExtractionData = [
         ['#title', fromProperty('innerText')],
       ],
       price: [
-        ['#price', inUnits(fromProperty('innerText'))],
+        ['#price', inUnits(fromChildrenText())],
       ],
       image: [
         ['img', fromProperty('src')],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -34,7 +34,8 @@
     "privacy",
     "webRequest",
     "webRequestBlocking",
-    "telemetry"
+    "telemetry",
+    "webNavigation"
   ],
   "experiment_apis": {
     "customizableUI": {


### PR DESCRIPTION
So the BOTW page is being extracted via selector instead of Fathom. One approach would have been to add some rules and include the page in our training, but I opted for the selector-based solution since I'm not set up for training yet and Erik is making some large changes to our ruleset currently.

- Switches selector-based price extraction to use the same method for splitting up price nodes as Fathom does, i.e. taking the text of the immediate children, as the BOTW page has a Home Depot-style price display.
- Adds detection for `pushState` calls in the page that change the page's URL. Since the contents of the page often change during these switches, and since product IDs are based off the URL, we should be re-extracting when this happens.
- Adds a new selector for product images from the BOTW product page.

The review is up for whoever gets to it first.