### PR TITLE
Fix #211: Only inject content scripts into http(s) pages.

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -45,7 +45,7 @@ import {registerEvents, handleWidgetRemoved} from 'commerce/telemetry/extension'
   // Store the return value globally to avoid destroying it, which would
   // unregister the content scripts.
   window.registeredContentScript = browser.contentScripts.register({
-    matches: ['<all_urls>'],
+    matches: ['https://*/*', 'http://*/*'],
     js: [
       {file: 'extraction.bundle.js'},
     ],
@@ -55,7 +55,7 @@ import {registerEvents, handleWidgetRemoved} from 'commerce/telemetry/extension'
 
   // Set up web request listener to modify framing headers for background updates
   const webRequestFilter = {
-    urls: ['<all_urls>'],
+    urls: ['https://*/*', 'http://*/*'],
     types: ['sub_frame'],
     tabId: browser.tabs.TAB_ID_NONE,
   };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,7 +26,8 @@
     "default_popup": "browser_action/index.html"
   },
   "permissions": [
-    "<all_urls>",
+    "https://*/*",
+    "http://*/*",
     "tabs",
     "storage",
     "unlimitedStorage",


### PR DESCRIPTION
There's some pending PRs with new URL matches that will need altering, I'll rebase this PR after they land.