### PR TITLE
Fix #212, fix #71: Validate extracted product data, including URL protocols.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2282,11 +2282,6 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
-    "check-prop-types": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/check-prop-types/-/check-prop-types-1.1.2.tgz",
-      "integrity": "sha512-hGDrZ1yhRgKuP1yzZ5sUX/PPmlKBLOF1GyF0Z008Sienko3BFZmlCXnmq+npRTIL/WlFCUzThyd+F5PQnnT1ug=="
-    },
     "cheerio": {
       "version": "1.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
@@ -2524,7 +2519,7 @@
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
       "dev": true
     },
     "colors": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "webpack --config webpack/dev.config.js",
     "build:prod": "webpack --config webpack/prod.config.js",
     "watch": "webpack --watch --config webpack/dev.config.js",
+    "watch:prod": "webpack --watch --config webpack/prod.config.js",
     "package": "web-ext build --source-dir build --overwrite-dest",
     "lint": "bin/run_lints.sh",
     "test": "bin/run_tests.py"
@@ -49,7 +50,6 @@
   },
   "dependencies": {
     "autobind-decorator": "2.1.0",
-    "check-prop-types": "1.1.2",
     "dinero.js": "1.4.0",
     "fathom-web": "2.3.0",
     "lodash.maxby": "4.6.0",

--- a/src/background/extraction.js
+++ b/src/background/extraction.js
@@ -9,8 +9,7 @@
 
 import config from 'commerce/config';
 import {updateProductWithExtracted} from 'commerce/background/price_updates';
-import {extractedProductShape} from 'commerce/state/products';
-import {validatePropType} from 'commerce/utils';
+import {isValidExtractedProduct} from 'commerce/state/products';
 
 /**
  * Triggers background tasks when a product is extracted from a webpage. Along
@@ -22,9 +21,8 @@ import {validatePropType} from 'commerce/utils';
  *  The sender for the content script that extracted this product
  */
 export async function handleExtractedProductData({extractedProduct}, sender) {
-  // Do nothing if the extracted product is missing fields.
-  const result = validatePropType(extractedProduct, extractedProductShape);
-  if (result !== undefined) {
+  // Do nothing if the extracted product isn't valid.
+  if (!isValidExtractedProduct(extractedProduct)) {
     return;
   }
 

--- a/src/state/products.js
+++ b/src/state/products.js
@@ -39,6 +39,39 @@ export const extractedProductShape = pt.shape({
   date: pt.string.isRequired,
 });
 
+/**
+ * Validate the contents of the given extracted product. This is used in lieu
+ * of proptypes since proptype checks do not work in a production build.
+ * @param {ExtractedProduct} extractedProduct
+ * @return {Boolean}
+ */
+export function isValidExtractedProduct(extractedProduct) {
+  if (typeof extractedProduct.title !== 'string') {
+    return false;
+  }
+
+  if (Number.isNaN(Date.parse(extractedProduct.date))) {
+    return false;
+  }
+
+  if (typeof extractedProduct.price !== 'number') {
+    return false;
+  }
+
+  for (const key of ['url', 'image']) {
+    try {
+      const url = new URL(extractedProduct[key]);
+      if (!['https:', 'http:'].includes(url.protocol)) {
+        return false;
+      }
+    } catch (err) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 
 // Actions
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import checkPropTypes from 'check-prop-types';
-
 /**
  * Resolves when the amount of time specified by delay has elapsed.
  */
@@ -38,16 +36,4 @@ export async function retry(callback, maxRetries = 5, delayFactor = 2, initialDe
     }
   }
   throw lastError;
-}
-
-/**
- * Wrapper for check-prop-types to check a propType against a single value.
- * @param {*} value Value to validate
- * @param {PropType} propType The Proptype to validate value against
- * @return {string|undefined}
- *  Undefined if the validation was successful, or an error string explaining
- *  why it failed.
- */
-export function validatePropType(value, propType) {
-  return checkPropTypes({value: propType}, {value}, 'prop', 'Validation');
 }


### PR DESCRIPTION
Making proptype checks work in production isn't really feasible, so we solve the
issue by just not trying!