### PR TITLE
Fix #185: Include privacy context info in telemetry pings.

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -158,12 +158,12 @@ Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site`
   - `'product_card'`: Sends the user to the product page for the given Product Card.
   - `'system_notification'`: Sends the user to the product page for the Price Alert displayed in the notification.
   - `'walmart_link'`: Sends the user to Walmart.
-- `'privacy_dnt'`: 'true' if the user has requested not to be tracked by websites, content, or advertising; otherwise 'false'.
-- `'privacy_tp'`: The user's tracking protection setting:
+- `'privacy_dnt'`: 'true' if the user has [requested not to be tracked by websites, content, or advertising](https://support.mozilla.org/en-US/kb/how-do-i-turn-do-not-track-feature); otherwise 'false'.
+- `'privacy_tp'`: The user's [tracking protection](https://support.mozilla.org/en-US/kb/tracking-protection) setting:
   - `'always'`: Tracking Protection is on
   - `'never'`: Tracking Protection is off
   - `'private_browsing'`: Tracking Protection is on in private browsing windows only
-- `'privacy_cookie'`: The user's cookie setting:
+- `'privacy_cookie'`: The user's [cookie setting](https://support.mozilla.org/en-US/kb/disable-third-party-cookies):
   - `'allow_all'`: Accept all cookies
   - `'reject_all'`: Reject all cookies
   - `'reject_third_party'`: Reject all third-party cookies

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -158,6 +158,16 @@ Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site`
   - `'product_card'`: Sends the user to the product page for the given Product Card.
   - `'system_notification'`: Sends the user to the product page for the Price Alert displayed in the notification.
   - `'walmart_link'`: Sends the user to Walmart.
+- `'do_not_track'`: 'true' if the user has requested not to be tracked by websites, content, or advertising; otherwise 'false'.
+- `'privacy_tp'`: The user's tracking protection setting:
+  - `'always'`: Tracking Protection is on
+  - `'never'`: Tracking Protection is off
+  - `'private_browsing'`: Tracking Protection is on in private browsing windows only
+- `'cookie_config'`: The user's cookie setting:
+  - `'allow_all'`: Accept all cookies
+  - `'reject_all'`: Reject all cookies
+  - `'reject_third_party'`: Reject all third-party cookies
+  - `'allow_visited'`: Accept a third-party cookie only if the cookie's top-level domain already has at least one cookie.
 
 
 ## Collection (User Events)

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -158,12 +158,12 @@ Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site`
   - `'product_card'`: Sends the user to the product page for the given Product Card.
   - `'system_notification'`: Sends the user to the product page for the Price Alert displayed in the notification.
   - `'walmart_link'`: Sends the user to Walmart.
-- `'do_not_track'`: 'true' if the user has requested not to be tracked by websites, content, or advertising; otherwise 'false'.
+- `'privacy_dnt'`: 'true' if the user has requested not to be tracked by websites, content, or advertising; otherwise 'false'.
 - `'privacy_tp'`: The user's tracking protection setting:
   - `'always'`: Tracking Protection is on
   - `'never'`: Tracking Protection is off
   - `'private_browsing'`: Tracking Protection is on in private browsing windows only
-- `'cookie_config'`: The user's cookie setting:
+- `'privacy_cookie'`: The user's cookie setting:
   - `'allow_all'`: Accept all cookies
   - `'reject_all'`: Reject all cookies
   - `'reject_third_party'`: Reject all third-party cookies

--- a/src/telemetry/extension.js
+++ b/src/telemetry/extension.js
@@ -13,13 +13,22 @@ import {getAllProducts} from 'commerce/state/products';
 
 const CATEGORY = 'extension.price_alerts';
 
+const DEFAULT_EXTRAS = [
+  'tracked_prods',
+  'do_not_track',
+  'privacy_tp',
+  'cookie_config',
+];
+
 const EVENTS = {
   // User Events
   // User visits a supported site
   visit_supported_site: {
     methods: ['visit_supported_site'],
     objects: ['supported_site'],
-    extra_keys: ['tracked_prods'],
+    extra_keys: [
+      ...DEFAULT_EXTRAS,
+    ],
   },
 
   // User clicks toolbar button to open the popup
@@ -28,7 +37,7 @@ const EVENTS = {
     objects: ['toolbar_button'],
     extra_keys: [
       'badge_type',
-      'tracked_prods',
+      ...DEFAULT_EXTRAS,
     ],
   },
   // User clicks on a UI element in the extension opening a page in a new tab
@@ -36,7 +45,7 @@ const EVENTS = {
     methods: ['open_external_page'],
     objects: ['ui_element'],
     extra_keys: [
-      'tracked_prods',
+      ...DEFAULT_EXTRAS,
       'element',
       // For 'element' values 'product_card' and 'system_notification' only
       'price',
@@ -54,7 +63,7 @@ const EVENTS = {
     extra_keys: [
       'price',
       'product_key',
-      'tracked_prods',
+      ...DEFAULT_EXTRAS,
     ],
   },
   // User deletes a product from the product listing
@@ -67,7 +76,7 @@ const EVENTS = {
       'price_orig',
       'product_index',
       'product_key',
-      'tracked_prods',
+      ...DEFAULT_EXTRAS,
     ],
   },
   // User undeletes a product from the product listing
@@ -80,7 +89,7 @@ const EVENTS = {
       'price_orig',
       'product_index',
       'product_key',
-      'tracked_prods',
+      ...DEFAULT_EXTRAS,
     ],
   },
   // User uninstalls the extension
@@ -95,7 +104,7 @@ const EVENTS = {
     objects: ['toolbar_button'],
     extra_keys: [
       'badge_type',
-      'tracked_prods',
+      ...DEFAULT_EXTRAS,
     ],
   },
 
@@ -108,7 +117,7 @@ const EVENTS = {
       'price',
       'price_orig',
       'product_key',
-      'tracked_prods',
+      ...DEFAULT_EXTRAS,
     ],
   },
 
@@ -118,7 +127,7 @@ const EVENTS = {
     objects: ['toolbar_button'],
     extra_keys: [
       'badge_type',
-      'tracked_prods',
+      ...DEFAULT_EXTRAS,
     ],
   },
   // System notification is sent notifying user of a price alert
@@ -129,7 +138,7 @@ const EVENTS = {
       'price',
       'price_orig',
       'product_key',
-      'tracked_prods',
+      ...DEFAULT_EXTRAS,
     ],
   },
   // Product extraction is attempted on the content page
@@ -139,7 +148,7 @@ const EVENTS = {
     extra_keys: [
       'extraction_id',
       'is_bg_update',
-      'tracked_prods',
+      ...DEFAULT_EXTRAS,
     ],
   },
   // Product extraction is completed on the content page
@@ -150,7 +159,7 @@ const EVENTS = {
       'extraction_id',
       'is_bg_update',
       'method',
-      'tracked_prods',
+      ...DEFAULT_EXTRAS,
     ],
   },
 };
@@ -168,6 +177,9 @@ export async function recordEvent(method, object, value, extraBase = {}) {
   const extra = {
     ...extraBase,
     tracked_prods: getAllProducts(store.getState()).length,
+    do_not_track: navigator.doNotTrack === '1',
+    privacy_tp: (await browser.privacy.websites.trackingProtectionMode.get({})).value,
+    cookie_config: (await browser.privacy.websites.cookieConfig.get({})).value.behavior,
   };
 
   // Convert all extra key values to strings as required by event telemetry

--- a/src/telemetry/extension.js
+++ b/src/telemetry/extension.js
@@ -15,9 +15,9 @@ const CATEGORY = 'extension.price_alerts';
 
 const DEFAULT_EXTRAS = [
   'tracked_prods',
-  'do_not_track',
+  'privacy_dnt',
   'privacy_tp',
-  'cookie_config',
+  'privacy_cookie',
 ];
 
 const EVENTS = {
@@ -177,9 +177,9 @@ export async function recordEvent(method, object, value, extraBase = {}) {
   const extra = {
     ...extraBase,
     tracked_prods: getAllProducts(store.getState()).length,
-    do_not_track: navigator.doNotTrack === '1',
+    privacy_dnt: navigator.doNotTrack === '1',
     privacy_tp: (await browser.privacy.websites.trackingProtectionMode.get({})).value,
-    cookie_config: (await browser.privacy.websites.cookieConfig.get({})).value.behavior,
+    privacy_cookie: (await browser.privacy.websites.cookieConfig.get({})).value.behavior,
   };
 
   // Convert all extra key values to strings as required by event telemetry


### PR DESCRIPTION
Note that some of the data being included describes situations in which telemetry currently isn't being collected, meaning it will effectively never be sent (e.g. Do Not Track being true). #186 will change that.