### PR TITLE
Fix #158: Add non-UI telemetry probes

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -86,7 +86,7 @@ We will be sending pings using [Event Telemetry](https://firefox-source-docs.moz
 
 Each event will exist as part of the `main` ping under `payload.processes.dynamic.events` as an array in the `events` array (see Appendix B for how to view the events in `about:telemetry`). The data types of individual fields for each event follow the Event Telemetry [serialization format](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html#serialization-format).
 
-The telemetry category for events is `'extension.price_alerts'`.
+The telemetry category for events is `'extension.price_wise'`.
 
 Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site` events.
 
@@ -103,7 +103,7 @@ Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site`
         "events": [
           [
             2079,
-            "extension.price_alerts",
+            "extension.price_wise",
             "badge_toolbar_button",
             "toolbar_button",
             null,
@@ -114,7 +114,7 @@ Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site`
           ],
           [
             2081,
-            "extension.price_alerts",
+            "extension.price_wise",
             "visit_supported_site",
             "supported_site",
             null,

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -88,7 +88,7 @@ Each event will exist as part of the `main` ping under `payload.processes.dynami
 
 The telemetry category for events is `'extension.price_wise'`.
 
-Below is a sample ping for the `visit_supported_site` and `badge_toolbar_button` events.
+Below is a sample ping for when the user visits a supported page and adds the product on that page.
 
 ```javascript
 {
@@ -102,18 +102,51 @@ Below is a sample ping for the `visit_supported_site` and `badge_toolbar_button`
         // ...
         "events": [
           [
-            733502,
+            7756,
             "extension.price_wise",
             "visit_supported_site",
             "supported_site",
             null,
             {
               "tracked_prods": "0",
-              "dnt_tp_cookie": "{\"dnt\":false,\"tp\":\"private_browsing\",\"cookie\":\"allow_visited\"}"
+              "privacy_dnt": "false",
+              "privacy_tp": "private_browsing",
+              "privacy_cookie": "allow_visited"
             }
           ],
           [
-            733530,
+            7769,
+            "extension.price_wise",
+            "attempt_extraction",
+            "product_page",
+            null,
+            {
+              "extraction_id": "67caf845-f971-42ce-8a9a-aa3ce919186f",
+              "is_bg_update": "false",
+              "tracked_prods": "0",
+              "privacy_dnt": "false",
+              "privacy_tp": "private_browsing",
+              "privacy_cookie": "allow_visited"
+            }
+          ],
+          [
+            7779,
+            "extension.price_wise",
+            "complete_extraction",
+            "product_page",
+            null,
+            {
+              "extraction_id": "67caf845-f971-42ce-8a9a-aa3ce919186f",
+              "is_bg_update": "false",
+              "method": "css_selectors",
+              "tracked_prods": "0",
+              "privacy_dnt": "false",
+              "privacy_tp": "private_browsing",
+              "privacy_cookie": "allow_visited"
+            }
+          ],
+          [
+            7783,
             "extension.price_wise",
             "badge_toolbar_button",
             "toolbar_button",
@@ -121,10 +154,41 @@ Below is a sample ping for the `visit_supported_site` and `badge_toolbar_button`
             {
               "badge_type": "add",
               "tracked_prods": "0",
-              "dnt_tp_cookie": "{\"dnt\":false,\"tp\":\"private_browsing\",\"cookie\":\"allow_visited\"}"
+              "privacy_dnt": "false",
+              "privacy_tp": "private_browsing",
+              "privacy_cookie": "allow_visited"
             }
-          ]
-        ]
+          ],
+          [
+            18180,
+            "extension.price_wise",
+            "open_popup",
+            "toolbar_button",
+            null,
+            {
+              "badge_type": "add",
+              "tracked_prods": "0",
+              "privacy_dnt": "false",
+              "privacy_tp": "private_browsing",
+              "privacy_cookie": "allow_visited"
+            }
+          ],
+          [
+            19565,
+            "extension.price_wise",
+            "add_product",
+            "add_button",
+            null,
+            {
+              "price": "4800",
+              "product_key": "2b4d8569-3db9-4448-a9d8-af1fc5cacf7a",
+              "tracked_prods": "1",
+              "privacy_dnt": "false",
+              "privacy_tp": "private_browsing",
+              "privacy_cookie": "allow_visited"
+            }
+          ],
+        ],
       }
       // ...
     }
@@ -143,17 +207,16 @@ Below is a sample ping for the `visit_supported_site` and `badge_toolbar_button`
 
 Some `extra_keys` are sent with every telemetry event recorded by the extension:
 - `'tracked_prods'`: The number of products the user is tracking.
-- `'dnt_tp_cookie'`: The status of three different privacy settings collapsed into a single, stringified JSON object:
-  - `'dnt'`: 'true' if the user has [requested not to be tracked by websites, content, or advertising](https://support.mozilla.org/en-US/kb/how-do-i-turn-do-not-track-feature); otherwise 'false'.
-  - `'tp'`: The user's [tracking protection](https://support.mozilla.org/en-US/kb/tracking-protection) setting:
-    - `'always'`: Tracking Protection is on
-    - `'never'`: Tracking Protection is off
-    - `'private_browsing'`: Tracking Protection is on in private browsing windows only
-  - `'cookie'`: The user's [cookie setting](https://support.mozilla.org/en-US/kb/disable-third-party-cookies):
-    - `'allow_all'`: Accept all cookies
-    - `'reject_all'`: Reject all cookies
-    - `'reject_third_party'`: Reject all third-party cookies
-    - `'allow_visited'`: Accept a third-party cookie only if the cookie's top-level domain already has at least one cookie.
+- `'privacy_dnt'`: 'true' if the user has [requested not to be tracked by websites, content, or advertising](https://support.mozilla.org/en-US/kb/how-do-i-turn-do-not-track-feature); otherwise 'false'.
+- `'privacy_tp'`: The user's [tracking protection](https://support.mozilla.org/en-US/kb/tracking-protection) setting:
+  - `'always'`: Tracking Protection is on
+  - `'never'`: Tracking Protection is off
+  - `'private_browsing'`: Tracking Protection is on in private browsing windows only
+- `'privacy_cookie'`: The user's [cookie setting](https://support.mozilla.org/en-US/kb/disable-third-party-cookies):
+  - `'allow_all'`: Accept all cookies
+  - `'reject_all'`: Reject all cookies
+  - `'reject_third_party'`: Reject all third-party cookies
+  - `'allow_visited'`: Accept a third-party cookie only if the cookie's top-level domain already has at least one cookie.
 
 ### Event-specific Extra Keys
 
@@ -166,8 +229,6 @@ Some `extra_keys` are sent with every telemetry event recorded by the extension:
   - `'help_button'`: Sends the user to a Price Wise support.mozilla.org page.
   - `'home_depot_link'`: Sends the user to Home Depot.
   - `'learn_more_link'`: Sends the user to a Price Wise support.mozilla.org page.
-  - `'product_card'`: Sends the user to the product page for the given Product Card.
-  - `'system_notification'`: Sends the user to the product page for the Price Alert displayed in the notification.
   - `'walmart_link'`: Sends the user to Walmart.
 - `'extraction_id'`: A unique identifier to associate an extraction attempt to an extraction completion event for a given page.
 - `'is_bg_update'`: 'true' if the extraction is associated with a background price check; otherwise 'false'.
@@ -209,28 +270,37 @@ Fired when the user clicks the Price Wise browserAction toolbar button to open t
   - `'badge_type'`
   - [Common extra keys](#common-extra-keys)
 
-### `open_external_page`
+### `open_nonproduct_page`
 
-Fired when the user clicks on a UI element in the extension that opens a page in a new tab.
+Fired when the user clicks on a UI element in the extension that opens a non-product page in a new tab.
 
 #### Payload properties
 - `methods`: String
-  - `'open_external_page'`
+  - `'open_nonproduct_page'`
 - `objects`: String
   - `'ui_element'`
-- `extra_keys`: Object; which keys are included depends on the value of the `'element'` extra key.
-  - All values:
-    - [Common extra keys](#common-extra-keys)
-    - `'element'`
-  - `'system_notification'` and `'product_card'` only:
-    - `'price'`
-    - `'price_alert'`
-    - `'price_orig'`
-    - `'product_key'`
-  - `'system_notification'` only:
-    - `'price_last_high'`
-  - `'product_card'` only:
-    - `'product_index'`
+- `extra_keys`: Object
+  - `'element'`
+  - [Common extra keys](#common-extra-keys)
+
+### `open_product_page`
+
+Fired when the user clicks on a UI element in the extension that opens a product page in a new tab.
+
+#### Payload properties
+- `methods`: String
+  - `'open_product_page'`
+- `objects`: String. The extension UI element that the user clicked to open a product page in a new tab. One of:
+  - `'product_card'`: Sends the user to the product page for the given Product Card.
+  - `'system_notification'`: Sends the user to the product page for the Price Alert displayed in the notification.
+- `extra_keys`: Object
+  - `'price'`
+  - `'price_alert'`
+  - `'price_orig'`
+  - `'product_key'`
+  - [Common extra keys](#common-extra-keys)
+  - `'product_index'` (for `objects` value of `'product_card'` only)
+  - `'price_last_high'` (for `objects` value of `'system_notification'` only)
 
 ### `add_product`
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -143,6 +143,8 @@ Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site`
 - `method`: The extraction method that was successful, if any. One of: 'fathom', 'fallback' or 'neither'. A value of 'neither' means that extraction failed.
 - `'price'`: The price of the product in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
 - `'price_alert'`: 'true' if the product has an active Price Alert; otherwise 'false'.
+- `'price_last_high'`: The last high price of the product in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
+  - A high price is, semantically, the price that there's been an interesting drop from to warrant alerting the user. Practically, it is the highest price since the previous price alert.
 - `'price_orig'`: The original price of the product in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
 - `'price_prev'`: The previous price of the product when different from the latest price (`price`) in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
 - `'product_index'`: The index of the product in the product listing. The top most list item is index '0'. The list is sorted by date added, descending (#113).
@@ -216,6 +218,8 @@ Fired when the user clicks on a UI element in the extension that opens a page in
     - `'price_alert'`
     - `'price_orig'`
     - `'product_key'`
+  - `'system_notification'` only:
+    - `'price_last_high'`
   - `'product_card'` only:
     - `'product_index'`
 
@@ -313,6 +317,7 @@ Fired whenever a price change (of any magnitude and in any direction) is detecte
 Fired whenever the toolbar is badged in response to:
 1. A successful product extraction or
 2. A Price Alert
+  - Note: For Price Alerts, this event will continue to trigger after the initial Price Alert is shown to the user until the Price Alert is dismissed (per the [UX spec](https://mozilla.invisionapp.com/share/UFNSHAIMT4V#/screens/317130676_Artboard_1) and when a system notification is clicked).
 
 #### Payload properties
 
@@ -336,6 +341,7 @@ Fired whenever a system notification is sent to the user notifying them of a Pri
   - `'system_notification'`
 - `extra_keys`: Object
   - `'price'`
+  - `'price_last_high'`
   - `'price_orig'`
   - `'product_key'`
   - `'tracked_prods'`

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -88,7 +88,7 @@ Each event will exist as part of the `main` ping under `payload.processes.dynami
 
 The telemetry category for events is `'extension.price_wise'`.
 
-Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site` events.
+Below is a sample ping for the `visit_supported_site` and `badge_toolbar_button` events.
 
 ```javascript
 {
@@ -102,24 +102,26 @@ Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site`
         // ...
         "events": [
           [
-            2079,
+            733502,
+            "extension.price_wise",
+            "visit_supported_site",
+            "supported_site",
+            null,
+            {
+              "tracked_prods": "0",
+              "dnt_tp_cookie": "{\"dnt\":false,\"tp\":\"private_browsing\",\"cookie\":\"allow_visited\"}"
+            }
+          ],
+          [
+            733530,
             "extension.price_wise",
             "badge_toolbar_button",
             "toolbar_button",
             null,
             {
               "badge_type": "add",
-              "tracked_prods": "5"
-            }
-          ],
-          [
-            2081,
-            "extension.price_wise",
-            "visit_supported_site",
-            "supported_site",
-            null,
-            {
-              "tracked_prods": "5"
+              "tracked_prods": "0",
+              "dnt_tp_cookie": "{\"dnt\":false,\"tp\":\"private_browsing\",\"cookie\":\"allow_visited\"}"
             }
           ]
         ]
@@ -133,11 +135,14 @@ Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site`
 ```
 
 
-## `extra_keys`
+## Extra Keys
 
 `extra_keys` are keys in the [optional `extra` object field](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html#serialization-format) for telemetry events. All `extra_keys` and their values are strings.
 
-- `'badge_type'`: Indicates what, if any, badge was present on the browserAction toolbar button. One of 'add', 'price_alert', or 'none'. A value of 'unknown' is possible if the badge text is unrecognized.
+### Common Extra Keys
+
+Some `extra_keys` are sent with every telemetry event recorded by the extension:
+- `'tracked_prods'`: The number of products the user is tracking.
 - `'dnt_tp_cookie'`: The status of three different privacy settings collapsed into a single, stringified JSON object:
   - `'dnt'`: 'true' if the user has [requested not to be tracked by websites, content, or advertising](https://support.mozilla.org/en-US/kb/how-do-i-turn-do-not-track-feature); otherwise 'false'.
   - `'tp'`: The user's [tracking protection](https://support.mozilla.org/en-US/kb/tracking-protection) setting:
@@ -149,18 +154,10 @@ Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site`
     - `'reject_all'`: Reject all cookies
     - `'reject_third_party'`: Reject all third-party cookies
     - `'allow_visited'`: Accept a third-party cookie only if the cookie's top-level domain already has at least one cookie.
-- `'extraction_id'`: A unique identifier to associate an extraction attempt to an extraction completion event for a given page.
-- `'is_bg_update'`: 'true' if the extraction is associated with a background price check; otherwise 'false'.
-- `method`: The extraction method that was successful, if any. One of: 'fathom', 'css_selectors', 'open_graph' or 'none'. A value of 'none' means that all extraction methods failed.
-- `'price'`: The price of the product in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
-- `'price_alert'`: 'true' if the product has an active Price Alert; otherwise 'false'.
-- `'price_last_high'`: The last high price of the product in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
-  - A high price is, semantically, the price that there's been an interesting drop from to warrant alerting the user. Practically, it is the highest price since the previous price alert.
-- `'price_orig'`: The original price of the product in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
-- `'price_prev'`: The previous price of the product when different from the latest price (`price`) in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
-- `'product_index'`: The index of the product in the product listing. The top most list item is index '0'. The list is sorted by date added, descending (#113).
-- `'product_key'`: A unique identifier for the product relative to other products for a given user. This key is _not_ unique to the product across all users.
-- `'tracked_prods'`: The number of products the user is tracking.
+
+### Event-specific Extra Keys
+
+- `'badge_type'`: Indicates what, if any, badge was present on the browserAction toolbar button. One of 'add', 'price_alert', or 'none'. A value of 'unknown' is possible if the badge text is unrecognized.
 - `'element'`: The extension UI element that the user clicked to open a page in a new tab. Note: All `*_link` elements exist in the Onboarding Popup only. One of...
   - `'amazon_link'`: Sends the user to Amazon.
   - `'best_buy_link'`: Sends the user to Best Buy.
@@ -172,6 +169,17 @@ Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site`
   - `'product_card'`: Sends the user to the product page for the given Product Card.
   - `'system_notification'`: Sends the user to the product page for the Price Alert displayed in the notification.
   - `'walmart_link'`: Sends the user to Walmart.
+- `'extraction_id'`: A unique identifier to associate an extraction attempt to an extraction completion event for a given page.
+- `'is_bg_update'`: 'true' if the extraction is associated with a background price check; otherwise 'false'.
+- `method`: The extraction method that was successful, if any. One of: 'fathom', 'css_selectors', 'open_graph' or 'none'. A value of 'none' means that all extraction methods failed.
+- `'price'`: The price of the product in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
+- `'price_alert'`: 'true' if the product has an active Price Alert; otherwise 'false'.
+- `'price_last_high'`: The last high price of the product in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
+  - A high price is, semantically, the price that there's been an interesting drop from to warrant alerting the user. Practically, it is the highest price since the previous price alert.
+- `'price_orig'`: The original price of the product in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
+- `'price_prev'`: The previous price of the product when different from the latest price (`price`) in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
+- `'product_index'`: The index of the product in the product listing. The top most list item is index '0'. The list is sorted by date added, descending (#113).
+- `'product_key'`: A unique identifier for the product relative to other products for a given user. This key is _not_ unique to the product across all users.
 
 
 ## Collection (User Events)
@@ -186,7 +194,7 @@ Fired when the user navigates to a Supported Site.
 - `objects`: String
   - `'supported_site'`
 - `extra_keys`: Object
-  - `'tracked_prods'`
+  - [Common extra keys](#common-extra-keys)
 
 ### `open_popup`
 
@@ -199,7 +207,7 @@ Fired when the user clicks the Price Wise browserAction toolbar button to open t
   - `'toolbar_button'`
 - `extra_keys`: Object
   - `'badge_type'`
-  - `'tracked_prods'`
+  - [Common extra keys](#common-extra-keys)
 
 ### `open_external_page`
 
@@ -212,7 +220,7 @@ Fired when the user clicks on a UI element in the extension that opens a page in
   - `'ui_element'`
 - `extra_keys`: Object; which keys are included depends on the value of the `'element'` extra key.
   - All values:
-    - `'tracked_prods'`
+    - [Common extra keys](#common-extra-keys)
     - `'element'`
   - `'system_notification'` and `'product_card'` only:
     - `'price'`
@@ -237,7 +245,7 @@ Fired when the user clicks the add product button in the browserAction popup.
 - `extra_keys`: Object
   - `'price'`
   - `'product_key'`
-  - `'tracked_prods'`
+  - [Common extra keys](#common-extra-keys)
 
 ### `delete_product`
 
@@ -255,7 +263,7 @@ Fired when the user clicks a delete product button in a Product Card in the brow
   - `'price_orig'`
   - `'product_index'`
   - `'product_key'`
-  - `'tracked_prods'`
+  - [Common extra keys](#common-extra-keys)
 
 ### `undo_delete_product`
 
@@ -273,7 +281,7 @@ Fired when the user clicks an undo button in a Product Card in the browserAction
   - `'price_orig'`
   - `'product_index'`
   - `'product_key'`
-  - `'tracked_prods'`
+  - [Common extra keys](#common-extra-keys)
 
 ### `uninstall`
 
@@ -291,7 +299,7 @@ Fired when the user hides the extension's browserAction toolbar button from the 
   - `'toolbar_button'`
 - `extra_keys`: Object
   - `'badge_type'`
-  - `'tracked_prods'`
+  - [Common extra keys](#common-extra-keys)
 
 
 ## Collection (Non-User Events)
@@ -311,7 +319,7 @@ Fired whenever a price change (of any magnitude and in any direction) is detecte
   - `'price_orig'`
   - `'price_prev'`
   - `'product_key'`
-  - `'tracked_prods'`
+  - [Common extra keys](#common-extra-keys)
 
 ### `badge_toolbar_button`
 
@@ -328,7 +336,7 @@ Fired whenever the toolbar is badged in response to:
   - `'toolbar_button'`
 - `extra_keys`: Object
   - `'badge_type'`
-  - `'tracked_prods'`
+  - [Common extra keys](#common-extra-keys)
 
 ### `send_notification`
 
@@ -345,7 +353,7 @@ Fired whenever a system notification is sent to the user notifying them of a Pri
   - `'price_last_high'`
   - `'price_orig'`
   - `'product_key'`
-  - `'tracked_prods'`
+  - [Common extra keys](#common-extra-keys)
 
 ### `attempt_extraction`
 
@@ -360,7 +368,7 @@ Fired whenever a supported page loads and the add-on attempts to extract product
 - `extra_keys`: Object
   - `'extraction_id'`
   - `'is_bg_update'`
-  - `'tracked_prods'`
+  - [Common extra keys](#common-extra-keys)
 
 ### `complete_extraction`
 
@@ -376,7 +384,7 @@ Fired whenever extraction on a supported page completes, whether or not the extr
   - `'extraction_id'`
   - `'is_bg_update'`
   - `method`
-  - `'tracked_prods'`
+  - [Common extra keys](#common-extra-keys)
 
 
 ## Opt-out

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -140,7 +140,7 @@ Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site`
 - `'badge_type'`: Indicates what, if any, badge was present on the browserAction toolbar button. One of 'add', 'price_alert', or 'none'. A value of 'unknown' is possible if the badge text is unrecognized.
 - `'extraction_id'`: A unique identifier to associate an extraction attempt to an extraction completion event for a given page.
 - `'is_bg_update'`: 'true' if the extraction is associated with a background price check; otherwise 'false'.
-- `method`: The extraction method that was successful, if any. One of: 'fathom', 'fallback' or 'neither'. A value of 'neither' means that extraction failed.
+- `method`: The extraction method that was successful, if any. One of: 'fathom', 'css_selectors', 'open_graph' or 'none'. A value of 'none' means that all extraction methods failed.
 - `'price'`: The price of the product in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
 - `'price_alert'`: 'true' if the product has an active Price Alert; otherwise 'false'.
 - `'price_last_high'`: The last high price of the product in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -3,7 +3,7 @@
 
 # Metrics
 
-A summary of the metrics the Price Alerts extension will record.
+A summary of the metrics the Price Wise extension will record.
 
 
 ## Definitions
@@ -21,7 +21,7 @@ A summary of the metrics the Price Alerts extension will record.
 
 ## Analysis
 
-Data collected by the Price Alerts extension will be used to answer the following questions:
+Data collected by the Price Wise extension will be used to answer the following questions:
 
 Note: For any questions related to general user shopping behavior, the data about what sites users visit is limited to the Supported Sites for the MVP.
 
@@ -84,7 +84,7 @@ While some of these questions may be partially answerable by this extension, ans
 
 We will be sending pings using [Event Telemetry](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html) via the [WebExtensions Telemetry API](https://bugzilla.mozilla.org/show_bug.cgi?id=1280234).
 
-Each event will exist as part of the `main` ping under `payload.processes.dynamic.events` as an array in the `events` array. The data types of individual fields for each event follow the Event Telemetry [serialization format](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html#serialization-format).
+Each event will exist as part of the `main` ping under `payload.processes.dynamic.events` as an array in the `events` array (see Appendix B for how to view the events in `about:telemetry`). The data types of individual fields for each event follow the Event Telemetry [serialization format](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html#serialization-format).
 
 The telemetry category for events is `'extension.price_alerts'`.
 
@@ -144,6 +144,7 @@ Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site`
 - `'price'`: The price of the product in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
 - `'price_alert'`: 'true' if the product has an active Price Alert; otherwise 'false'.
 - `'price_orig'`: The original price of the product in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
+- `'price_prev'`: The previous price of the product when different from the latest price (`price`) in subunits (e.g. a $10.00 product would have a value of `'1000'`). For the MVP, the units here are always cents (USD currency only).
 - `'product_index'`: The index of the product in the product listing. The top most list item is index '0'. The list is sorted by date added, descending (#113).
 - `'product_key'`: A unique identifier for the product relative to other products for a given user. This key is _not_ unique to the product across all users.
 - `'tracked_prods'`: The number of products the user is tracking.
@@ -152,9 +153,9 @@ Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site`
   - `'best_buy_link'`: Sends the user to Best Buy.
   - `'ebay_link'`: Sends the user to Ebay.
   - `'feedback_button'`: Sends the user to a feedback Survey.
-  - `'help_button'`: Sends the user to a Price Alerts support.mozilla.org page.
+  - `'help_button'`: Sends the user to a Price Wise support.mozilla.org page.
   - `'home_depot_link'`: Sends the user to Home Depot.
-  - `'learn_more_link'`: Sends the user to a Price Alerts support.mozilla.org page.
+  - `'learn_more_link'`: Sends the user to a Price Wise support.mozilla.org page.
   - `'product_card'`: Sends the user to the product page for the given Product Card.
   - `'system_notification'`: Sends the user to the product page for the Price Alert displayed in the notification.
   - `'walmart_link'`: Sends the user to Walmart.
@@ -186,7 +187,7 @@ Fired when the user navigates to a Supported Site.
 
 ### `open_popup`
 
-Fired when the user clicks the Price Alerts browserAction toolbar button to open the popup.
+Fired when the user clicks the Price Wise browserAction toolbar button to open the popup.
 
 #### Payload properties
 - `methods`: String
@@ -303,6 +304,7 @@ Fired whenever a price change (of any magnitude and in any direction) is detecte
 - `extra_keys`: Object
   - `'price'`
   - `'price_orig'`
+  - `'price_prev'`
   - `'product_key'`
   - `'tracked_prods'`
 
@@ -427,3 +429,10 @@ Note: This is a sample ping. The exact value for the extension ID may differ, th
   // ...
 }
 ```
+
+### Appendix B: How to view Price Wise events in `about:telemetry`
+
+1. Navigate to `about:telemetry`.
+2. Click 'Events' in the sidebar menu.
+  - Note: This menu item is not present until an event has been recorded for the current session. If you don't see it, trigger one of the events as described in this document (e.g. `open_popup`) and refresh the page.
+3. On the top right corner of the next page, click 'dynamic' in the dropdown menu.

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -138,6 +138,17 @@ Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site`
 `extra_keys` are keys in the [optional `extra` object field](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html#serialization-format) for telemetry events. All `extra_keys` and their values are strings.
 
 - `'badge_type'`: Indicates what, if any, badge was present on the browserAction toolbar button. One of 'add', 'price_alert', or 'none'. A value of 'unknown' is possible if the badge text is unrecognized.
+- `'dnt_tp_cookie'`: The status of three different privacy settings collapsed into a single, stringified JSON object:
+  - `'dnt'`: 'true' if the user has [requested not to be tracked by websites, content, or advertising](https://support.mozilla.org/en-US/kb/how-do-i-turn-do-not-track-feature); otherwise 'false'.
+  - `'tp'`: The user's [tracking protection](https://support.mozilla.org/en-US/kb/tracking-protection) setting:
+    - `'always'`: Tracking Protection is on
+    - `'never'`: Tracking Protection is off
+    - `'private_browsing'`: Tracking Protection is on in private browsing windows only
+  - `'cookie'`: The user's [cookie setting](https://support.mozilla.org/en-US/kb/disable-third-party-cookies):
+    - `'allow_all'`: Accept all cookies
+    - `'reject_all'`: Reject all cookies
+    - `'reject_third_party'`: Reject all third-party cookies
+    - `'allow_visited'`: Accept a third-party cookie only if the cookie's top-level domain already has at least one cookie.
 - `'extraction_id'`: A unique identifier to associate an extraction attempt to an extraction completion event for a given page.
 - `'is_bg_update'`: 'true' if the extraction is associated with a background price check; otherwise 'false'.
 - `method`: The extraction method that was successful, if any. One of: 'fathom', 'css_selectors', 'open_graph' or 'none'. A value of 'none' means that all extraction methods failed.
@@ -161,16 +172,6 @@ Below is a sample ping for the `badge_toolbar_button` and `visit_supported_site`
   - `'product_card'`: Sends the user to the product page for the given Product Card.
   - `'system_notification'`: Sends the user to the product page for the Price Alert displayed in the notification.
   - `'walmart_link'`: Sends the user to Walmart.
-- `'privacy_dnt'`: 'true' if the user has [requested not to be tracked by websites, content, or advertising](https://support.mozilla.org/en-US/kb/how-do-i-turn-do-not-track-feature); otherwise 'false'.
-- `'privacy_tp'`: The user's [tracking protection](https://support.mozilla.org/en-US/kb/tracking-protection) setting:
-  - `'always'`: Tracking Protection is on
-  - `'never'`: Tracking Protection is off
-  - `'private_browsing'`: Tracking Protection is on in private browsing windows only
-- `'privacy_cookie'`: The user's [cookie setting](https://support.mozilla.org/en-US/kb/disable-third-party-cookies):
-  - `'allow_all'`: Accept all cookies
-  - `'reject_all'`: Reject all cookies
-  - `'reject_third_party'`: Reject all third-party cookies
-  - `'allow_visited'`: Accept a third-party cookie only if the cookie's top-level domain already has at least one cookie.
 
 
 ## Collection (User Events)

--- a/src/background/extraction.js
+++ b/src/background/extraction.js
@@ -10,6 +10,7 @@
 import config from 'commerce/config';
 import {updateProductWithExtracted} from 'commerce/background/price_updates';
 import {isValidExtractedProduct} from 'commerce/state/products';
+import {recordEvent} from 'commerce/telemetry/extension';
 
 /**
  * Triggers background tasks when a product is extracted from a webpage. Along
@@ -20,7 +21,7 @@ import {isValidExtractedProduct} from 'commerce/state/products';
  * @param {MessageSender} sender
  *  The sender for the content script that extracted this product
  */
-export async function handleExtractedProductData({extractedProduct}, sender) {
+export async function handleExtractedProductData({extractedProduct, sendTelemetry = true}, sender) {
   // Do nothing if the extracted product isn't valid.
   if (!isValidExtractedProduct(extractedProduct)) {
     return;
@@ -51,6 +52,11 @@ export async function handleExtractedProductData({extractedProduct}, sender) {
       tabId,
     });
     browser.browserAction.setBadgeText({text: '✚', tabId});
+    if (sendTelemetry) {
+      await recordEvent('badge_toolbar_button', 'toolbar_button', null, {
+        badge_type: 'add',
+      });
+    }
   }
 
   // Update saved product data if it exists

--- a/src/background/extraction.js
+++ b/src/background/extraction.js
@@ -10,7 +10,7 @@
 import config from 'commerce/config';
 import {updateProductWithExtracted} from 'commerce/background/price_updates';
 import {isValidExtractedProduct} from 'commerce/state/products';
-import {recordEvent} from 'commerce/telemetry/extension';
+import {recordEvent, hasBadgeTextChanged} from 'commerce/telemetry/extension';
 
 /**
  * Triggers background tasks when a product is extracted from a webpage. Along
@@ -21,7 +21,7 @@ import {recordEvent} from 'commerce/telemetry/extension';
  * @param {MessageSender} sender
  *  The sender for the content script that extracted this product
  */
-export async function handleExtractedProductData({extractedProduct, sendTelemetry = true}, sender) {
+export async function handleExtractedProductData({extractedProduct}, sender) {
   // Do nothing if the extracted product isn't valid.
   if (!isValidExtractedProduct(extractedProduct)) {
     return;
@@ -51,12 +51,12 @@ export async function handleExtractedProductData({extractedProduct, sendTelemetr
       color: await config.get('badgeDetectBackground'),
       tabId,
     });
-    browser.browserAction.setBadgeText({text: '✚', tabId});
-    if (sendTelemetry) {
+    if (await hasBadgeTextChanged('✚', sender.tab.id)) {
       await recordEvent('badge_toolbar_button', 'toolbar_button', null, {
         badge_type: 'add',
       });
     }
+    browser.browserAction.setBadgeText({text: '✚', tabId});
   }
 
   // Update saved product data if it exists

--- a/src/background/extraction.js
+++ b/src/background/extraction.js
@@ -10,7 +10,7 @@
 import config from 'commerce/config';
 import {updateProductWithExtracted} from 'commerce/background/price_updates';
 import {isValidExtractedProduct} from 'commerce/state/products';
-import {recordEvent, hasBadgeTextChanged} from 'commerce/telemetry/extension';
+import {recordEvent, getToolbarBadgeText} from 'commerce/telemetry/extension';
 
 /**
  * Triggers background tasks when a product is extracted from a webpage. Along
@@ -51,7 +51,7 @@ export async function handleExtractedProductData({extractedProduct}, sender) {
       color: await config.get('badgeDetectBackground'),
       tabId,
     });
-    if (await hasBadgeTextChanged('✚', sender.tab.id)) {
+    if (await getToolbarBadgeText(tabId) !== '✚') {
       await recordEvent('badge_toolbar_button', 'toolbar_button', null, {
         badge_type: 'add',
       });

--- a/src/background/price_alerts.js
+++ b/src/background/price_alerts.js
@@ -22,7 +22,7 @@ import {
 } from 'commerce/state/prices';
 import {getProduct} from 'commerce/state/products';
 import {getVendor} from 'commerce/state/vendors';
-import {recordEvent, hasBadgeTextChanged} from 'commerce/telemetry/extension';
+import {recordEvent, getToolbarBadgeText} from 'commerce/telemetry/extension';
 
 /**
  * Update the extension UI based on the current state of active price alerts.
@@ -34,7 +34,7 @@ export async function handlePriceAlerts() {
 
   // Show the browser action badge if there are any active alerts.
   if (activeAlerts.length > 0) {
-    if (await hasBadgeTextChanged(`${activeAlerts.length}`)) {
+    if (await getToolbarBadgeText() !== `${activeAlerts.length}`) {
       await recordEvent('badge_toolbar_button', 'toolbar_button', null, {
         badge_type: 'price_alert',
       });

--- a/src/background/price_alerts.js
+++ b/src/background/price_alerts.js
@@ -97,8 +97,7 @@ export async function handleNotificationClicked(notificationId) {
     // Record open_external_page event
     const latestPrice = getLatestPriceForProduct(state, product.id);
     const originalPrice = getOldestPriceForProduct(state, product.id);
-    await recordEvent('open_external_page', 'ui_element', null, {
-      element: 'system_notification',
+    await recordEvent('open_product_page', 'system_notification', null, {
       price: latestPrice.amount.getAmount(),
       price_alert: alert.active,
       price_last_high: alert.highPriceAmount,

--- a/src/background/price_alerts.js
+++ b/src/background/price_alerts.js
@@ -22,7 +22,7 @@ import {
 } from 'commerce/state/prices';
 import {getProduct} from 'commerce/state/products';
 import {getVendor} from 'commerce/state/vendors';
-import {recordEvent} from 'commerce/telemetry/extension';
+import {recordEvent, hasBadgeTextChanged} from 'commerce/telemetry/extension';
 
 /**
  * Update the extension UI based on the current state of active price alerts.
@@ -34,10 +34,12 @@ export async function handlePriceAlerts() {
 
   // Show the browser action badge if there are any active alerts.
   if (activeAlerts.length > 0) {
+    if (await hasBadgeTextChanged(`${activeAlerts.length}`)) {
+      await recordEvent('badge_toolbar_button', 'toolbar_button', null, {
+        badge_type: 'price_alert',
+      });
+    }
     browser.browserAction.setBadgeText({text: `${activeAlerts.length}`});
-    await recordEvent('badge_toolbar_button', 'toolbar_button', null, {
-      badge_type: 'price_alert',
-    });
   } else {
     browser.browserAction.setBadgeText({text: null});
   }
@@ -66,7 +68,7 @@ export async function handlePriceAlerts() {
     });
     await recordEvent('send_notification', 'system_notification', null, { // eslint-disable-line no-await-in-loop
       price: alertPrice.amount.getAmount(),
-      price_last_high: highPriceAmount.getAmount(),
+      price_last_high: alert.highPriceAmount,
       price_orig: originalPrice.amount.getAmount(),
       product_key: product.anonId,
     });
@@ -95,12 +97,11 @@ export async function handleNotificationClicked(notificationId) {
     // Record open_external_page event
     const latestPrice = getLatestPriceForProduct(state, product.id);
     const originalPrice = getOldestPriceForProduct(state, product.id);
-    const highPriceAmount = Dinero({amount: alert.highPriceAmount});
     await recordEvent('open_external_page', 'ui_element', null, {
       element: 'system_notification',
       price: latestPrice.amount.getAmount(),
       price_alert: alert.active,
-      price_last_high: highPriceAmount.getAmount(),
+      price_last_high: alert.highPriceAmount,
       price_orig: originalPrice.amount.getAmount(),
       product_key: product.anonId,
     });

--- a/src/background/price_updates.js
+++ b/src/background/price_updates.js
@@ -99,7 +99,7 @@ export async function updateProductWithExtracted(data) {
       const updatedState = store.getState();
       const latestPrice = getLatestPriceForProduct(updatedState, id);
       const originalPrice = getOldestPriceForProduct(updatedState, id);
-      recordEvent('detect_price_change', 'product_page', null, {
+      await recordEvent('detect_price_change', 'product_page', null, {
         price: latestPrice.amount.getAmount(),
         price_prev: previousPrice.amount.getAmount(),
         price_orig: originalPrice.amount.getAmount(),

--- a/src/background/price_updates.js
+++ b/src/background/price_updates.js
@@ -91,16 +91,13 @@ export async function updateProductWithExtracted(data) {
   const id = getProductIdFromExtracted(data);
   const product = getProduct(state, id);
   if (product) {
-    const isPriceChange = await store.dispatch(addPriceFromExtracted(data));
-    if (isPriceChange) {
+    const price = await store.dispatch(addPriceFromExtracted(data));
+    if (price) {
       // Record the detect_price_change event
       const previousPrice = getLatestPriceForProduct(state, id);
-      // Need to refetch state, since we just added a price entry for this product
-      const updatedState = store.getState();
-      const latestPrice = getLatestPriceForProduct(updatedState, id);
-      const originalPrice = getOldestPriceForProduct(updatedState, id);
+      const originalPrice = getOldestPriceForProduct(state, id);
       await recordEvent('detect_price_change', 'product_page', null, {
-        price: latestPrice.amount.getAmount(),
+        price: price.amount,
         price_prev: previousPrice.amount.getAmount(),
         price_orig: originalPrice.amount.getAmount(),
         product_key: product.anonId,

--- a/src/browser_action/components/BrowserActionApp.jsx
+++ b/src/browser_action/components/BrowserActionApp.jsx
@@ -69,7 +69,7 @@ export default class BrowserActionApp extends React.Component {
    */
   async handleClickHelp() {
     browser.tabs.create({url: await config.get('supportUrl')});
-    await recordEvent('open_external_page', 'ui_element', null, {element: 'help_button'});
+    await recordEvent('open_nonproduct_page', 'ui_element', null, {element: 'help_button'});
     window.close();
   }
 
@@ -78,7 +78,7 @@ export default class BrowserActionApp extends React.Component {
    */
   async handleClickFeedback() {
     browser.tabs.create({url: await config.get('feedbackUrl')});
-    await recordEvent('open_external_page', 'ui_element', null, {element: 'feedback_button'});
+    await recordEvent('open_nonproduct_page', 'ui_element', null, {element: 'feedback_button'});
     window.close();
   }
 

--- a/src/browser_action/components/EmptyOnboarding.jsx
+++ b/src/browser_action/components/EmptyOnboarding.jsx
@@ -50,7 +50,7 @@ export default class EmptyOnboarding extends React.Component {
     if (event.target.href) {
       event.preventDefault();
       browser.tabs.create({url: event.target.href});
-      await recordEvent('open_external_page', 'ui_element', null, {element: `${event.target.dataset.telemetryId}_link`});
+      await recordEvent('open_nonproduct_page', 'ui_element', null, {element: `${event.target.dataset.telemetryId}_link`});
       window.close();
     }
   }

--- a/src/browser_action/components/ProductCard.jsx
+++ b/src/browser_action/components/ProductCard.jsx
@@ -63,7 +63,7 @@ export default class ProductCard extends React.Component {
    */
   async handleClick() {
     browser.tabs.create({url: this.props.product.url});
-    await this.recordClickEvent('open_external_page', 'ui_element', {element: 'product_card'});
+    await this.recordClickEvent('open_product_page', 'product_card');
     window.close();
   }
 

--- a/src/extraction/index.js
+++ b/src/extraction/index.js
@@ -42,9 +42,10 @@ function extractProduct() {
   return null;
 }
 
-async function sendProductToBackground(extractedProduct) {
+async function sendProductToBackground(extractedProduct, sendTelemetry) {
   return browser.runtime.sendMessage({
     type: 'extracted-product',
+    sendTelemetry,
     extractedProduct: {
       ...extractedProduct,
       url: document.location.href,
@@ -111,8 +112,9 @@ async function attemptExtraction() {
 
   // Messy workaround for bug 1493470: Resend product info to the background
   // script twice in case subframe loads clear the toolbar icon.
-  // TODO(osmose): Remove once Firefox 64 hits the release channel.
-  const resend = () => sendProductToBackground(extractedProduct);
+  // TODO(osmose): Remove once Firefox 64 hits the release channel, including second argument
+  // to sendProductToBackground.
+  const resend = () => sendProductToBackground(extractedProduct, false);
   setTimeout(resend, 5000);
   setTimeout(resend, 10000);
 

--- a/src/state/prices.js
+++ b/src/state/prices.js
@@ -229,13 +229,9 @@ export function addPriceFromExtracted(data) {
       // Potentially trigger an alert since there's a new price in town.
       dispatch(triggerPriceAlert(price));
 
-      // If this isn't the first price for this product, record detect_price_change event
-      const prices = getPricesForProduct(state, price.productId);
-      if (prices.length >= 1) {
-        return true;
-      }
+      return price;
     }
-    return false;
+    return null;
   };
 }
 

--- a/src/state/prices.js
+++ b/src/state/prices.js
@@ -211,7 +211,8 @@ export default function reducer(state = initialState(), action) {
 // Action Creators
 
 /**
- * Adds a new price to the store.
+ * Adds a new price to the store. Returns true if the extracted price
+ * is different than the last known price in state.
  * @param {ExtractedProduct} data
  */
 export function addPriceFromExtracted(data) {
@@ -227,7 +228,14 @@ export function addPriceFromExtracted(data) {
 
       // Potentially trigger an alert since there's a new price in town.
       dispatch(triggerPriceAlert(price));
+
+      // If this isn't the first price for this product, record detect_price_change event
+      const prices = getPricesForProduct(state, price.productId);
+      if (prices.length >= 1) {
+        return true;
+      }
     }
+    return false;
   };
 }
 

--- a/src/telemetry/extension.js
+++ b/src/telemetry/extension.js
@@ -15,7 +15,9 @@ const CATEGORY = 'extension.price_wise';
 
 const DEFAULT_EXTRAS = [
   'tracked_prods',
-  'dnt_tp_cookie',
+  'privacy_dnt',
+  'privacy_tp',
+  'privacy_cookie',
 ];
 
 const EVENTS = {
@@ -38,22 +40,29 @@ const EVENTS = {
       ...DEFAULT_EXTRAS,
     ],
   },
-  // User clicks on a UI element in the extension opening a page in a new tab
-  open_external_page: {
-    methods: ['open_external_page'],
+  // User clicks on a UI element in the extension opening a non-product page in a new tab
+  open_nonproduct_page: {
+    methods: ['open_nonproduct_page'],
     objects: ['ui_element'],
     extra_keys: [
-      ...DEFAULT_EXTRAS,
       'element',
-      // For 'element' values 'product_card' and 'system_notification' only
+      ...DEFAULT_EXTRAS,
+    ],
+  },
+  // User clicks on a UI element in the extension opening a product page in a new tab
+  open_product_page: {
+    methods: ['open_product_page'],
+    objects: ['product_card', 'system_notification'],
+    extra_keys: [
       'price',
       'price_alert',
       'price_orig',
       'product_key',
-      // For 'element' value of 'system_notification' only
-      'price_last_high',
-      // For 'element' value 'product_card' only
+      ...DEFAULT_EXTRAS,
+      // For 'objects' value 'product_card' only
       'product_index',
+      // For 'objects' value of 'system_notification' only
+      'price_last_high',
     ],
   },
   // User adds a product to the product listing
@@ -173,11 +182,9 @@ export async function recordEvent(method, object, value, extraBase = {}) {
   const extra = {
     ...extraBase,
     tracked_prods: getAllProducts(store.getState()).length,
-    dnt_tp_cookie: JSON.stringify({
-      dnt: (navigator.doNotTrack === '1'),
-      tp: (await browser.privacy.websites.trackingProtectionMode.get({})).value,
-      cookie: (await browser.privacy.websites.cookieConfig.get({})).value.behavior,
-    }),
+    privacy_dnt: navigator.doNotTrack === '1',
+    privacy_tp: (await browser.privacy.websites.trackingProtectionMode.get({})).value,
+    privacy_cookie: (await browser.privacy.websites.cookieConfig.get({})).value.behavior,
   };
 
   // Convert all extra key values to strings as required by event telemetry

--- a/src/telemetry/extension.js
+++ b/src/telemetry/extension.js
@@ -11,7 +11,7 @@ import {shouldCollectTelemetry} from 'commerce/privacy';
 import store from 'commerce/state';
 import {getAllProducts} from 'commerce/state/products';
 
-const CATEGORY = 'extension.price_alerts';
+const CATEGORY = 'extension.price_wise';
 
 const DEFAULT_EXTRAS = [
   'tracked_prods',

--- a/src/telemetry/extension.js
+++ b/src/telemetry/extension.js
@@ -214,10 +214,7 @@ async function getActiveTabId() {
 
 export async function getBadgeType() {
   // browserAction and background scripts have to use activeTabId as a proxy for the tabId
-  const activeTabId = await getActiveTabId();
-  const badgeText = await browser.browserAction.getBadgeText(
-    activeTabId ? {tabId: activeTabId} : {},
-  );
+  const badgeText = await getToolbarBadgeText(await getActiveTabId());
   switch (true) {
     case (badgeText === ''):
       return 'none';
@@ -231,17 +228,13 @@ export async function getBadgeType() {
   }
 }
 
-export async function hasBadgeTextChanged(nextText, tabId = null) {
-  // If the nextText contains a digit, we know it's a price alert badge, which only affects
-  // the global badge text.
-  const returnGlobal = (/\d+/.test(nextText));
-  const prevText = await browser.browserAction.getBadgeText(
-    returnGlobal ? {} : {tabId: tabId || await getActiveTabId()},
+export async function getToolbarBadgeText(tabId = null) {
+  // The 'add' badge modifies badge text for a specific tab and will have a tabId.
+  // The 'price_alert' badge modifies the global badge text and will not have a tabId.
+  const returnGlobal = !tabId;
+  return browser.browserAction.getBadgeText(
+    returnGlobal ? {} : {tabId},
   );
-  if (prevText !== nextText) {
-    return true;
-  }
-  return false;
 }
 
 export async function handleWidgetRemoved(widgetId) {

--- a/src/telemetry/extension.js
+++ b/src/telemetry/extension.js
@@ -92,12 +92,6 @@ const EVENTS = {
       ...DEFAULT_EXTRAS,
     ],
   },
-  // User uninstalls the extension
-  uninstall: {
-    methods: ['uninstall'],
-    objects: ['uninstall'],
-    extra_keys: ['tracked_prods'],
-  },
   // User hides the toolbar button for the extension
   hide_toolbar_button: {
     methods: ['hide_toolbar_button'],

--- a/src/telemetry/extension.js
+++ b/src/telemetry/extension.js
@@ -206,6 +206,7 @@ async function getActiveTabId() {
 }
 
 export async function getBadgeType() {
+  // browserAction and background scripts have to use activeTabId as a proxy for the tabId
   const activeTabId = await getActiveTabId();
   const badgeText = await browser.browserAction.getBadgeText(
     activeTabId ? {tabId: activeTabId} : {},
@@ -221,6 +222,19 @@ export async function getBadgeType() {
       console.warn(`Unexpected badge text ${badgeText}.`); // eslint-disable-line no-console
       return 'unknown';
   }
+}
+
+export async function hasBadgeTextChanged(nextText, tabId = null) {
+  // If the nextText contains a digit, we know it's a price alert badge, which only affects
+  // the global badge text.
+  const returnGlobal = (/\d+/.test(nextText));
+  const prevText = await browser.browserAction.getBadgeText(
+    returnGlobal ? {} : {tabId: tabId || await getActiveTabId()},
+  );
+  if (prevText !== nextText) {
+    return true;
+  }
+  return false;
 }
 
 export async function handleWidgetRemoved(widgetId) {

--- a/src/telemetry/extension.js
+++ b/src/telemetry/extension.js
@@ -15,9 +15,7 @@ const CATEGORY = 'extension.price_wise';
 
 const DEFAULT_EXTRAS = [
   'tracked_prods',
-  'privacy_dnt',
-  'privacy_tp',
-  'privacy_cookie',
+  'dnt_tp_cookie',
 ];
 
 const EVENTS = {
@@ -181,9 +179,11 @@ export async function recordEvent(method, object, value, extraBase = {}) {
   const extra = {
     ...extraBase,
     tracked_prods: getAllProducts(store.getState()).length,
-    privacy_dnt: navigator.doNotTrack === '1',
-    privacy_tp: (await browser.privacy.websites.trackingProtectionMode.get({})).value,
-    privacy_cookie: (await browser.privacy.websites.cookieConfig.get({})).value.behavior,
+    dnt_tp_cookie: JSON.stringify({
+      dnt: (navigator.doNotTrack === '1'),
+      tp: (await browser.privacy.websites.trackingProtectionMode.get({})).value,
+      cookie: (await browser.privacy.websites.cookieConfig.get({})).value.behavior,
+    }),
   };
 
   // Convert all extra key values to strings as required by event telemetry

--- a/src/telemetry/extension.js
+++ b/src/telemetry/extension.js
@@ -115,6 +115,7 @@ const EVENTS = {
     objects: ['product_page'],
     extra_keys: [
       'price',
+      'price_prev',
       'price_orig',
       'product_key',
       ...DEFAULT_EXTRAS,

--- a/src/telemetry/extension.js
+++ b/src/telemetry/extension.js
@@ -231,9 +231,8 @@ export async function getBadgeType() {
 export async function getToolbarBadgeText(tabId = null) {
   // The 'add' badge modifies badge text for a specific tab and will have a tabId.
   // The 'price_alert' badge modifies the global badge text and will not have a tabId.
-  const returnGlobal = !tabId;
   return browser.browserAction.getBadgeText(
-    returnGlobal ? {} : {tabId},
+    tabId ? {tabId} : {},
   );
 }
 

--- a/src/telemetry/extension.js
+++ b/src/telemetry/extension.js
@@ -52,6 +52,8 @@ const EVENTS = {
       'price_alert',
       'price_orig',
       'product_key',
+      // For 'element' value of 'system_notification' only
+      'price_last_high',
       // For 'element' value 'product_card' only
       'product_index',
     ],
@@ -137,6 +139,7 @@ const EVENTS = {
     objects: ['system_notification'],
     extra_keys: [
       'price',
+      'price_last_high',
       'price_orig',
       'product_key',
       ...DEFAULT_EXTRAS,


### PR DESCRIPTION
Broke this up into a few commits. Also updated the extension's name and telemetry category in `METRICS.md` and added a new Appendix section to explain how to find the probes (mostly for QA).

I don’t like how I get the “previous price” (I refetch `state`) for the `detect_price_change` probe, but I didn't see another way.