### PR TITLE
Fix #230: Constrain width of entire popup with lower and upper bounds

### DIFF
--- a/src/browser_action/components/EmptyOnboarding.css
+++ b/src/browser_action/components/EmptyOnboarding.css
@@ -9,9 +9,8 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  margin: 16px auto;
+  margin: 16px;
   text-align: center;
-  width: 288px;
 }
 
 .empty-onboarding .hero {

--- a/src/browser_action/components/ProductCard.css
+++ b/src/browser_action/components/ProductCard.css
@@ -9,7 +9,7 @@
   cursor: pointer;
   display: grid;
   gap: 8px;
-  grid-template-columns: 20px minmax(204px, 284px) 64px;
+  grid-template-columns: 20px auto 64px;
   grid-template-rows: auto 20px;
   height: 88px;
   overflow: hidden;

--- a/src/browser_action/index.css
+++ b/src/browser_action/index.css
@@ -22,6 +22,8 @@ body {
 
 #browser-action-app {
   min-width: 320px;
+  max-width: 400px; /* Overflow menu popup width exceeds 320px and cannot be changed */
+  width: 100%;
 }
 
 /** Links */


### PR DESCRIPTION
In previous PRs (#214, #215 and #218) CSS fixes were added to partially constrain either the whole popup or sections of it, leaving the 'Undo' section out. This patch puts a min-width and max-width on the whole popup, while flexibly sizing all its child containers, ensuring that the fixes applied in previous PRs remain in place.

Unfortunately, the Overflow menu has a width greater than our ideal popup width of 320px per the [UX spec](https://mozilla.invisionapp.com/share/UFNSHAIMT4V#/screens/317130676_Artboard_1), and that width cannot be controlled by a Web Extension, so I have set the max-width to 400px which will ensure the width of the popup doesn't change whether the toolbar button is in the overflow menu or not (previously, it would be one width when opened from the overflow menu and another width when opened otherwise).

One idea for the future is to try and detect whether the toolbar button is in the overflow menu or not and change classes accordingly via an experimental API, but that seems like overkill for now.