### PR TITLE
Fix #147: Update product information during re-extraction

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -70,7 +70,7 @@ import {registerEvents, handleWidgetRemoved} from 'commerce/telemetry/extension'
   // TODO(osmose): Remove once Firefox 64 hits the release channel.
   browser.webRequest.onCompleted.addListener(
     (details) => {
-      if (details.tabId) {
+      if (details.tabId && details.tabId !== browser.tabs.TAB_ID_NONE) {
         browser.tabs.sendMessage(details.tabId, {type: 'resend-product'});
       }
     },

--- a/src/state/products.js
+++ b/src/state/products.js
@@ -99,6 +99,7 @@ export function isValidExtractedProduct(extractedProduct) {
 export const ADD_PRODUCT = 'commerce/products/ADD_PRODUCT'; // Used by price duck
 const SET_DELETION_FLAG = 'commerce/products/SET_DELETION_FLAG';
 export const REMOVE_MARKED_PRODUCTS = 'commerce/products/REMOVE_MARKED_PRODUCTS';
+const UPDATE_PRODUCT = 'commerce/products/UPDATE_PRODUCT';
 
 // Reducer
 
@@ -135,6 +136,21 @@ export default function reducer(state = initialState(), action) {
       return {
         ...state,
         products: state.products.filter(product => !product.isDeleted),
+      };
+    }
+    case UPDATE_PRODUCT: {
+      const updatedProduct = getProductFromExtracted(
+        {...action.extractedProductData},
+        action.anonId,
+      );
+      return {
+        ...state,
+        products: state.products.map((product) => {
+          if (product.id === action.productId) {
+            return {...updatedProduct};
+          }
+          return product;
+        }),
       };
     }
     default:
@@ -179,6 +195,19 @@ export function setDeletionFlag(productId, deletionFlag) {
 export function removeMarkedProducts() {
   return {
     type: REMOVE_MARKED_PRODUCTS,
+  };
+}
+
+/**
+ * Update an existing product in the store.
+ * @param {ExtractedProduct} data
+ */
+export function updateProductFromExtracted(data, productId, anonId) {
+  return {
+    type: UPDATE_PRODUCT,
+    extractedProductData: data,
+    productId,
+    anonId,
   };
 }
 


### PR DESCRIPTION
@Osmose , ready for your review!

I have one specific question for you:
- I update the product in the `updateProductWithExtraction` function in `./src/background/price_updates.js`. This seemed like the least amount of code to change to get the job done, but perhaps there's a better approach in terms of code organization that you would recommend?
  - One option is to rename `price_updates.js` to `product_updates.js`.
  - Another option is to break out the product update portion of the code into a separate function, though I'm not sure where it would live.

Edit: Here is an easy way to test the patch:

1. In `updateProductWithExtracted` in `./src/background/price_updates.js`, Add this line temporarily just before dispatching the new update action (`await store.dispatch(updateProductFromExtracted(data, id, product.anonId));`):
```javascript
data = {...data, title: 'All Might is cool.'}; // eslint-disable-line
```
2. Add the Fake Product Page product
3. Refresh the page
4. Open the Popup
5. Notice the title of the product in the Product Card has changed from "Fake Product" to "All Might is cool."
