### PR TITLE
Fix #256: Change popup width in overflow menu

### DIFF
--- a/src/browser_action/index.css
+++ b/src/browser_action/index.css
@@ -21,8 +21,10 @@ body {
 }
 
 #browser-action-app {
-  min-width: 320px;
-  max-width: 400px; /* Overflow menu popup width exceeds 320px and cannot be changed */
+  width: 320px;
+}
+
+#browser-action-app.overflow {
   width: 100%;
 }
 

--- a/src/browser_action/index.jsx
+++ b/src/browser_action/index.jsx
@@ -20,6 +20,12 @@ if (extractedProductJSON) {
   appProps.extractedProduct = JSON.parse(extractedProductJSON);
 }
 
+(async function checkOverflow() {
+  if (await browser.customizableUI.isWidgetInOverflow('shopping-testpilot_mozilla_org-browser-action')) {
+    document.getElementById('browser-action-app').classList.add('overflow');
+  }
+}());
+
 ReactDOM.render(
   <Provider store={store}>
     <BrowserActionApp {...appProps} />

--- a/src/experiment_apis/customizableUI/api.js
+++ b/src/experiment_apis/customizableUI/api.js
@@ -1,14 +1,14 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-/* global ChromeUtils ExtensionAPI ExtensionCommon */
+/* global ChromeUtils ExtensionAPI */
 
 this.customizableUI = class extends ExtensionAPI {
   getAPI(context) {
-    const {Services} = ChromeUtils.import('resource://gre/modules/Services.jsm');
-    ChromeUtils.import('resource://gre/modules/ExtensionCommon.jsm');
+    const {CustomizableUI} = ChromeUtils.import('resource:///modules/CustomizableUI.jsm');
+    const {ExtensionCommon} = ChromeUtils.import('resource://gre/modules/ExtensionCommon.jsm');
     const {EventManager} = ExtensionCommon;
-    const {CustomizableUI} = ChromeUtils.import('resource:///modules/CustomizableUI.jsm', {});
+    const {Services} = ChromeUtils.import('resource://gre/modules/Services.jsm');
     return {
       customizableUI: {
         onWidgetRemoved: new EventManager(
@@ -27,8 +27,12 @@ this.customizableUI = class extends ExtensionAPI {
           },
         ).api(),
         async isWidgetInOverflow(widgetId) {
+          const {area} = CustomizableUI.getPlacementOfWidget(widgetId);
           const browserWindow = Services.wm.getMostRecentWindow('navigator:browser');
-          return CustomizableUI.getWidget(widgetId).forWindow(browserWindow).overflowed;
+          // First check is for the non-fixed overflow menu (e.g. widget moved by resizing window)
+          // Second is for fixed overflow menu (e.g. widget moved by (un)pinning button to overflow)
+          return (CustomizableUI.getWidget(widgetId).forWindow(browserWindow).overflowed
+            || area === 'widget-overflow-fixed-list');
         },
       },
     };

--- a/src/experiment_apis/customizableUI/api.js
+++ b/src/experiment_apis/customizableUI/api.js
@@ -31,7 +31,8 @@ this.customizableUI = class extends ExtensionAPI {
           const browserWindow = Services.wm.getMostRecentWindow('navigator:browser');
           // First check is for the non-fixed overflow menu (e.g. widget moved by resizing window)
           // Second is for fixed overflow menu (e.g. widget moved by (un)pinning button to overflow)
-          return (CustomizableUI.getWidget(widgetId).forWindow(browserWindow).overflowed
+          return (
+            CustomizableUI.getWidget(widgetId).forWindow(browserWindow).overflowed
             || area === 'widget-overflow-fixed-list');
         },
       },

--- a/src/experiment_apis/customizableUI/api.js
+++ b/src/experiment_apis/customizableUI/api.js
@@ -5,6 +5,7 @@
 
 this.customizableUI = class extends ExtensionAPI {
   getAPI(context) {
+    const {Services} = ChromeUtils.import('resource://gre/modules/Services.jsm');
     ChromeUtils.import('resource://gre/modules/ExtensionCommon.jsm');
     const {EventManager} = ExtensionCommon;
     const {CustomizableUI} = ChromeUtils.import('resource:///modules/CustomizableUI.jsm', {});
@@ -25,6 +26,10 @@ this.customizableUI = class extends ExtensionAPI {
             };
           },
         ).api(),
+        async isWidgetInOverflow(widgetId) {
+          const browserWindow = Services.wm.getMostRecentWindow('navigator:browser');
+          return CustomizableUI.getWidget(widgetId).forWindow(browserWindow).overflowed;
+        },
       },
     };
   }

--- a/src/experiment_apis/customizableUI/schema.json
+++ b/src/experiment_apis/customizableUI/schema.json
@@ -14,6 +14,21 @@
           }
         ]
       }
+    ],
+    "functions": [
+      {
+        "name": "isWidgetInOverflow",
+        "type": "function",
+        "description": "Returns a boolean for whether or not the provided widget in the provided window is in the overflow menu or not.",
+        "async": true,
+        "parameters": [
+          {
+            "name": "widgetId",
+            "type": "string",
+            "description": "The id of the widget to check."
+          }
+        ]
+      }
     ]
   }
 ]

--- a/src/experiment_apis/customizableUI/schema.json
+++ b/src/experiment_apis/customizableUI/schema.json
@@ -5,7 +5,7 @@
       {
         "name": "onWidgetRemoved",
         "type": "function",
-        "description": "Fired when a widget is removed from the browser chrome",
+        "description": "Fired when a widget is removed from the browser chrome.",
         "parameters": [
           {
             "name": "widgetId",
@@ -19,7 +19,7 @@
       {
         "name": "isWidgetInOverflow",
         "type": "function",
-        "description": "Returns a boolean for whether or not the provided widget in the provided window is in the overflow menu or not.",
+        "description": "Determine whether or not a widget is in the overflow menu.",
         "async": true,
         "parameters": [
           {


### PR DESCRIPTION
With CustomizableUI.jsm (via the experimental `browser.customizableUI` API added in #157), it is possible to detect when the browserAction toolbar button is and is not in the Overflow menu.

Because the overflow menu width varies by OS (for example, it is 377px wide on my Mac 10.13 and 425px wide on a Linux 14.04 (see screenshots below for confirmation)), this patch will detect whether or not the toolbar button is in the Overflow menu and adjust the width accordingly.

This fix has the added benefit of allowing us to constrain the non-Overflow menu popup width (which is hopefully the vast majority use case) to the UX spec of 320px where previously we had set it to a max-width of 400px to try to accommodate Overflow menu issues.

**Verified issue on Linux 14.04 (v11.0.0 prior to this patch!) in Firefox Nightly 65 and Release 63 shows that the popup width exceeds our CSS specified max-width of 400px**
![256-overflow-menu](https://user-images.githubusercontent.com/17437436/48583075-1e61ae00-e8db-11e8-84d2-943b9eee7de1.png)
![256-overflow-menu-2](https://user-images.githubusercontent.com/17437436/48583105-26b9e900-e8db-11e8-9af2-10f31e48f7bd.png)
