### PR TITLE
Fix #177: Disable price polling in Private Browsing windows

### DIFF
--- a/src/privacy.js
+++ b/src/privacy.js
@@ -44,8 +44,7 @@ export async function shouldCollectTelemetry(method) {
  * @return {boolean}
  */
 export async function shouldUpdatePrices() {
-  // TODO (bdanforth): Add private browsing check per #177
-  return true;
+  return !isActiveWindowPrivate();
 }
 
 async function trackingProtectionEnabled() {
@@ -68,4 +67,9 @@ async function cookiesBlocked() {
   }
 
   return true;
+}
+
+async function isActiveWindowPrivate() {
+  const activeWindow = await browser.windows.getCurrent();
+  return activeWindow.incognito;
 }

--- a/src/privacy.js
+++ b/src/privacy.js
@@ -44,7 +44,7 @@ export async function shouldCollectTelemetry(method) {
  * @return {boolean}
  */
 export async function shouldUpdatePrices() {
-  return !isActiveWindowPrivate();
+  return !(await isActiveWindowPrivate());
 }
 
 async function trackingProtectionEnabled() {


### PR DESCRIPTION
@Osmose , ready for your review!

Update `shouldUpdatePrices` with a check for whether or not the active window is a private window.

I did not add a check for `isActiveWindowPrivate` in `shouldExtract` in `./src/privacy.js`, despite the fact that `browser.extension.inIncognitoContext` r[eturns the "wrong" value for background extraction](https://github.com/mozilla/price-wise/pull/168#discussion_r225766093), because background extraction is gated by the `shouldUpdatePrices` check.