### PR TITLE
Fix #280: Use Firefox background colors for doorhanger footer

### DIFF
--- a/src/browser_action/components/StudyFooter.css
+++ b/src/browser_action/components/StudyFooter.css
@@ -4,7 +4,16 @@
 
 /** Study footer styles */
 
-.menu-item.study {
+.menu-item.study:enabled {
   justify-content: center;
   border-top: 1px solid var(--grey-30);
+  background-color: var(--grey-90-a10);
+}
+
+.menu-item.study:enabled:hover {
+  background-color: var(--grey-90-a20);
+}
+
+.menu-item.study:enabled:active {
+  background-color: var(--grey-90-a30);
 }


### PR DESCRIPTION
@Osmose Ready for your review!

Doorhanger footer styles are not specified in https://design.firefox.com/photon/components/doorhangers.html, nor do I see the colors I believe are correct (https://searchfox.org/mozilla-central/source/browser/themes/linux/browser.css#21-23) in the Photon Colors stylesheet (https://github.com/FirefoxUX/photon-colors/blob/master/photon-colors.css), but I can confirm by looking at the source code and a visual inspection that these are the right colors for the different states of buttons. I asked in slack #dsg (design system guidelines) about this lack of clarity.