### PR TITLE
Add filters to properly trigger new jobs as part of approval workflow.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,16 @@ workflows:
           type: approval
           requires:
             - sign
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - upload:
           requires:
             - hold
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
Turns out without tag filters the new jobs weren't running when I put up a tag. Whoops.