### PR TITLE
Fix #266: Update onboarding string to note support for U.S. domains only

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -205,6 +205,7 @@ Some `extra_keys` are sent with every telemetry event recorded by the extension:
 - `'badge_type'`: Indicates what, if any, badge was present on the browserAction toolbar button. One of 'add', 'price_alert', or 'none'. A value of 'unknown' is possible if the badge text is unrecognized.
 - `'element'`: The extension UI element that the user clicked to open a page in a new tab. Note: All `*_link` elements exist in the Onboarding Popup only. One of...
   - `'amazon_link'`: Sends the user to Amazon.
+  - `'amazon_smile_link'`: Sends the user to AmazonSmile.
   - `'best_buy_link'`: Sends the user to Best Buy.
   - `'ebay_link'`: Sends the user to eBay.
   - `'feedback_button'`: Sends the user to a feedback Survey.

--- a/src/browser_action/components/EmptyOnboarding.jsx
+++ b/src/browser_action/components/EmptyOnboarding.jsx
@@ -70,13 +70,14 @@ export default class EmptyOnboarding extends React.Component {
           {' '} in the spots where whitespace would otherwise be collapsed.
         */}
         <p className="description">
-          Add products you want to buy from
-          {' '}<a data-telemetry-id="amazon" href="https://www.amazon.com">Amazon</a>,
+          Add products from
+          {' '}<a data-telemetry-id="amazon" href="https://www.amazon.com">Amazon</a>
+          {' '}and <a data-telemetry-id="amazon_smile" href="https://smile.amazon.com">AmazonSmile</a>,
           {' '}<a data-telemetry-id="best_buy" href="https://www.bestbuy.com/">Best Buy</a>,
           {' '}<a data-telemetry-id="ebay" href="https://www.ebay.com/">eBay</a>,
-          {' '}<a data-telemetry-id="home_depot" href="https://www.homedepot.com/">Home Depot</a>, and
+          {' '}<a data-telemetry-id="home_depot" href="https://www.homedepot.com/">Home Depot</a> and
           {' '}<a data-telemetry-id="walmart" href="https://www.walmart.com/">Walmart</a>
-          {' '}to your Price Watcher list, and Firefox will notify you if the price drops.
+          {' '}(U.S. domains only for now). When Price Wise finds a price drop, the add-on gives you a heads-up about the lower price.
         </p>
         <p className="description">
           Price Wise keeps track of your saved products by occasionally loading their webpages in


### PR DESCRIPTION
Also update METRICS.md to add the `'amazon_smile_link'` value for the `element` extra key for the `open_nonproduct_page` event, since that was part of the string change request as well.

@Osmose ready for your review!