### PR TITLE
Fix #290: Do not allow scrollbars on the entire popup itself.

### DIFF
--- a/src/browser_action/index.css
+++ b/src/browser_action/index.css
@@ -16,7 +16,7 @@ body {
   font-size: 13px;
   margin: 0;
   max-height: 600px;
-  overflow: auto;
+  overflow: hidden;
   padding: 0;
 }
 


### PR DESCRIPTION
This overflow declaration was added in #215, nominally to help deal with
overflow issues when pinned to the overflow menu, but it's not clear how this
particular line helps vs the other changes to the width of the onboarding
view.

My theory on why this is biting us now:

- #256 updated the popup to a fixed width when not in the overflow menu, and a
  flexible width when it is.
- When we have more items than the 600px max height in the popup, we overflow
  and add a vertical toolbar inside.
- The vertical toolbar increases the desired width of the popup, causing the
  body element to add a horizontal scrollbar.
- The horizontal scrollbar increases the height beyond the 600px limit (since
  the initial overflow is contained within the product listing), causing the
  body element to add a vertical scrollbar.

If we force the body element to hide overflow, it refuses to add scrollbars, and
the overflow scrollbar on the product listing is overlaid correctly. This should
be safe to do now that we flex the width of the popup based on where it is
located.