### PR TITLE
Remove UR study UI

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -95,9 +95,8 @@ const CONFIG = {
     'www.mkelly.me',
   ]),
 
-  // TODO (bdanforth) Revert PR#278 after 11/26/18
   /** Temporary Cyber Monday study UI feature flag */
-  enableStudyUI: new BoolValue(true),
+  enableStudyUI: new BoolValue(false),
   /** URL for the study's recruitment survey */
   studyUrl: new StringValue('https://qsurvey.mozilla.com/s3/Price-Wise-Research-Study'),
 };


### PR DESCRIPTION
@Osmose Ready for your review!

I checked this (on Mac OS) for all channels (Nightly, Beta and Release) to ensure the list displays properly still without the footer in light of previous scrollbar/overflow display issues.

<img width="374" alt="screen shot 2018-11-30 at 10 35 41 am" src="https://user-images.githubusercontent.com/17437436/49309182-33b80a00-f48f-11e8-9ae9-a180a34f84ed.png">


----

Per sharonbautista in #274, this can now be removed. However, also per sharonbautista, it is possible we will want to recruit study participants from the extension in the future, so I have just turned the feature flag off in config rather than completely reverting PR#278.