### PR TITLE
#302: Remove links to deleted SUMO page.

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -196,9 +196,7 @@ Some `extra_keys` are sent with every telemetry event recorded by the extension:
   - `'best_buy_link'`: Sends the user to Best Buy.
   - `'ebay_link'`: Sends the user to eBay.
   - `'feedback_button'`: Sends the user to a feedback Survey.
-  - `'help_button'`: Sends the user to a Price Wise support.mozilla.org page.
   - `'home_depot_link'`: Sends the user to Home Depot.
-  - `'learn_more_link'`: Sends the user to a Price Wise support.mozilla.org page.
   - `'walmart_link'`: Sends the user to Walmart.
 - `'extraction_id'`: A unique identifier to associate an extraction attempt to an extraction completion event for a given page.
 - `'is_bg_update'`: 'true' if the extraction is associated with a background price check; otherwise 'false'.

--- a/src/browser_action/components/BrowserActionApp.css
+++ b/src/browser_action/components/BrowserActionApp.css
@@ -5,14 +5,17 @@
 /** Top-level components for the toolbar panel */
 
 .title-bar {
-  align-items: center;
   border-bottom: 1px solid var(--grey-30);
-  display: flex;
   height: 42px;
-  justify-content: space-between;
   margin: 0;
   overflow: hidden;
   padding: 0 8px;
+}
+
+.title-bar .feedback {
+  position: absolute;
+  top: 5px;
+  left: 5px;
 }
 
 .title-bar .title {

--- a/src/browser_action/components/BrowserActionApp.jsx
+++ b/src/browser_action/components/BrowserActionApp.jsx
@@ -71,15 +71,6 @@ export default class BrowserActionApp extends React.Component {
   }
 
   /**
-   * Open the support page and close the panel when the help icon is clicked.
-   */
-  async handleClickHelp() {
-    browser.tabs.create({url: await config.get('supportUrl')});
-    await recordEvent('open_nonproduct_page', 'ui_element', null, {element: 'help_button'});
-    window.close();
-  }
-
-  /**
    * Open the feedback page and close the panel when the help icon is clicked.
    */
   async handleClickFeedback() {
@@ -138,14 +129,6 @@ export default class BrowserActionApp extends React.Component {
             />
           </button>
           <h1 className="title">Products</h1>
-          <button
-            className="ghost help button"
-            type="button"
-            onClick={this.handleClickHelp}
-            title="Help"
-          >
-            <img className="icon" src={browser.extension.getURL('img/help.svg')} alt="Help" />
-          </button>
         </div>
         {products.length < 1
           ? (

--- a/src/browser_action/components/EmptyOnboarding.jsx
+++ b/src/browser_action/components/EmptyOnboarding.jsx
@@ -6,7 +6,6 @@ import autobind from 'autobind-decorator';
 import React from 'react';
 
 import TrackProductButton from 'commerce/browser_action/components/TrackProductButton';
-import config from 'commerce/config';
 import {extractedProductShape} from 'commerce/state/products';
 import {recordEvent} from 'commerce/telemetry/extension';
 
@@ -26,23 +25,6 @@ export default class EmptyOnboarding extends React.Component {
     extractedProduct: null,
   }
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      learnMoreHref: null,
-    };
-  }
-
-  /**
-   * Fetch the link to the support page on mount, since we can't fetch it async
-   * during the render.
-   */
-  async componentDidMount() {
-    this.setState({
-      learnMoreHref: await config.get('supportUrl'),
-    });
-  }
-
   /**
    * Open a new tab and close the popup when links are clicked.
    */
@@ -57,7 +39,6 @@ export default class EmptyOnboarding extends React.Component {
 
   render() {
     const {extractedProduct} = this.props;
-    const {learnMoreHref} = this.state;
     return (
       <div className="empty-onboarding" onClick={this.handleClick}>
         <img className="hero" src={browser.extension.getURL('img/shopping-welcome.svg')} alt="" />
@@ -83,7 +64,6 @@ export default class EmptyOnboarding extends React.Component {
           Price Wise keeps track of your saved products by occasionally loading their webpages in
           the background while Firefox is open.
         </p>
-        <a data-telemetry-id="learn_more" href={learnMoreHref} className="learn-more">Learn More</a>
         <TrackProductButton className="button" extractedProduct={extractedProduct} />
       </div>
     );

--- a/src/config.js
+++ b/src/config.js
@@ -72,9 +72,6 @@ const CONFIG = {
   /** Color of the toolbar badge when a product on the current page is trackable. */
   badgeDetectBackground: new StringValue('#33F70C'),
 
-  /** URL for the add-on's page on support.mozilla.org */
-  supportUrl: new StringValue('https://support.mozilla.org/kb/new-test-pilot-experiments'),
-
   /** URL for the add-on's feedback form */
   feedbackUrl: new StringValue('https://qsurvey.mozilla.com/s3/price-wise'),
 


### PR DESCRIPTION
Not much point in linking to a page that doesn't exist anymore. I already checked with product and they're fine with this.